### PR TITLE
Figure out why flight aware routes aren't saving properly

### DIFF
--- a/server/src/models/FlightAwareRoute.mts
+++ b/server/src/models/FlightAwareRoute.mts
@@ -40,7 +40,7 @@ flightAwareRouteSchema.virtual("filedAltitudesFormatted").get(function () {
   )}-${formatAltitude(this.filedAltitudeMax)}`;
 });
 
-flightAwareRouteSchema.set("toJSON", { virtuals: true });
+flightAwareRouteSchema.set("toJSON", { virtuals: ["filedAltitudesFormatted"] });
 
 const FlightAwareRoute: FlightAwareRouteModelInterface = mongoose.model<
   IFlightAwareRoute,


### PR DESCRIPTION
Fixes #29

Magic undocumented feature grrrr. Pass an array of string values of the virtual properties that should export instead of just setting true.