### PR TITLE
RVSM altitude check shouldn't warn when there is no equipment suffix

### DIFF
--- a/server/src/controllers/verifiers/nonRVSMIsBelow290.mts
+++ b/server/src/controllers/verifiers/nonRVSMIsBelow290.mts
@@ -1,6 +1,7 @@
 import { IFlightPlan } from "../../models/FlightPlan.mjs";
 import VerifierResult from "../../models/VerifierResult.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
+import hasEquipmentSuffix from "./hasEquipmentSuffix.mjs";
 
 const verifierName = "nonRVSMIsBelow290";
 
@@ -8,6 +9,7 @@ export default async function nonRVSMIsBelow290({
   _id,
   isRVSMCapable,
   cruiseAltitude,
+  equipmentSuffix,
 }: IFlightPlan): Promise<VerifierControllerResult> {
   // Set up the default result for a successful run of the verifier.
   var result: VerifierControllerResult = {
@@ -26,6 +28,12 @@ export default async function nonRVSMIsBelow290({
       result.data.status = "Information";
       result.data.message = `Plane is RVSM capable so no need to verify its altitude for RVSM compatibility.`;
       result.data.messageId = "RVSMCapable";
+    }
+    // Can't run check if there's no equipment suffix
+    else if (!equipmentSuffix) {
+      result.data.status = "Information";
+      result.data.message = `No equipment suffix available so unable to verify altitude for RVSM compatibility.`;
+      result.data.messageId = "noEquipmentSuffix";
     }
     // Plane isn't RVSM capable so make sure it isn't flying too high
     else if (cruiseAltitude >= 290) {

--- a/server/test/verifiers/nonRVSMIsBelow290.spec.mts
+++ b/server/test/verifiers/nonRVSMIsBelow290.spec.mts
@@ -74,6 +74,17 @@ const testData = [
     route: "SEA8 SEA BUWZO KRATR2",
     squawk: "1234",
   },
+  // No equipment suffix
+  {
+    _id: "5f9f7b3b9d3b3c1b1c9b4b57",
+    callsign: "ASA42",
+    departure: "KPDX",
+    arrival: "KSEA",
+    cruiseAltitude: 290,
+    rawAircraftType: "B737",
+    route: "SEA8 SEA BUWZO KRATR2",
+    squawk: "1234",
+  },
 ];
 
 describe("verifier: nonRVSMIsBelow290 tests", () => {
@@ -163,5 +174,19 @@ describe("verifier: nonRVSMIsBelow290 tests", () => {
     expect(data.status).to.equal("Information");
     expect(data.flightPlanPart).to.equal("cruiseAltitude");
     expect(data.messageId).to.equal("nonRVSMBelow290");
+  });
+
+  it("should pass because plane has no equipment suffix", async () => {
+    const flightPlan = await getFlightPlan("5f9f7b3b9d3b3c1b1c9b4b57");
+    expect(flightPlan.success).to.equal(true);
+
+    const result = await nonRVSMIsBelow290((flightPlan as SuccessResult<IFlightPlan>).data);
+
+    expect(result.success).to.equal(true);
+
+    const data = (result as SuccessResult<IVerifierResult>).data;
+    expect(data.status).to.equal("Information");
+    expect(data.flightPlanPart).to.equal("cruiseAltitude");
+    expect(data.messageId).to.equal("noEquipmentSuffix");
   });
 });


### PR DESCRIPTION
Fixes #93