### PR TITLE
Figure out why some of the tests are throwing 404 exceptions

### DIFF
--- a/server/src/controllers/flightAwareAirports.mts
+++ b/server/src/controllers/flightAwareAirports.mts
@@ -46,8 +46,9 @@ export async function getFlightAwareAirport(
       success: true,
       data: airport,
     };
-  } catch (error) {
-    console.error(error);
+  } catch (err) {
+    const error = err as Error;
+    console.error(error.message);
     return {
       success: false,
       errorType: "UnknownError",

--- a/server/src/controllers/flightAwareRoutes.mts
+++ b/server/src/controllers/flightAwareRoutes.mts
@@ -58,8 +58,9 @@ export async function getFlightAwareRoutes({
         resultRoutes.push(newRoute);
       })
     );
-  } catch (error) {
-    console.error(error);
+  } catch (err) {
+    const error = err as Error;
+    console.error(error.message);
     return {
       success: false,
       errorType: "UnknownError",

--- a/server/src/controllers/verifiers/routeWithFlightAware.mts
+++ b/server/src/controllers/verifiers/routeWithFlightAware.mts
@@ -84,13 +84,14 @@ export default async function routeWithFlightAware({
     }
 
     await result.data.save();
-  } catch (error) {
-    console.log(`Error running verifyRouteWithFlightAware: error`);
+  } catch (err) {
+    const error = err as Error;
+    console.log(`Error running verifyRouteWithFlightAware: ${error.message}}`);
 
     result = {
       success: false,
       errorType: "UnknownError",
-      error: `Error running verifyRouteWithFlightAware: error`,
+      error: `Error running verifyRouteWithFlightAware: ${error.message}`,
     };
   }
 

--- a/server/src/controllers/verifiers/validArrivalAirport.mts
+++ b/server/src/controllers/verifiers/validArrivalAirport.mts
@@ -34,13 +34,14 @@ export default async function validArrivalAirport({
     }
 
     await result.data.save();
-  } catch (error) {
-    console.log(`Error running validArrivalAirport: error`);
+  } catch (err) {
+    const error = err as Error;
+    console.log(`Error running validArrivalAirport: ${error.message}`);
 
     result = {
       success: false,
       errorType: "UnknownError",
-      error: `Error running validArrivalAirport: error`,
+      error: `Error running validArrivalAirport: ${error.message}`,
     };
   }
 

--- a/server/src/controllers/verifiers/validDepartureAirport.mts
+++ b/server/src/controllers/verifiers/validDepartureAirport.mts
@@ -34,13 +34,14 @@ export default async function validDepartureAirport({
     }
 
     await result.data.save();
-  } catch (error) {
-    console.log(`Error running validDepartureAirport: error`);
+  } catch (err) {
+    const error = err as Error;
+    console.log(`Error running validDepartureAirport: ${error.message}`);
 
     result = {
       success: false,
       errorType: "UnknownError",
-      error: `Error running validDepartureAirport: error`,
+      error: `Error running validDepartureAirport: ${error.message}`,
     };
   }
 

--- a/server/test/verifiers/checkForPreferredRoutes.spec.mts
+++ b/server/test/verifiers/checkForPreferredRoutes.spec.mts
@@ -5,10 +5,7 @@ import checkForPreferredRoutes from "../../src/controllers/verifiers/checkForPre
 import { IFlightPlan } from "../../src/models/FlightPlan.mjs";
 import { IVerifierResult } from "../../src/models/VerifierResult.mjs";
 import { SuccessResult } from "../../src/types/result.mjs";
-import {
-  addFlightPlans,
-  removeFlightPlans,
-} from "../setup/manageFlightPlans.mjs";
+import { addFlightPlans, removeFlightPlans } from "../setup/manageFlightPlans.mjs";
 
 const testData = [
   // No preferred route
@@ -69,23 +66,15 @@ const testData = [
 ];
 
 describe("verifier: checkForPreferredRoutes tests", () => {
-  before(
-    "Add flight plans for tests",
-    async () => await addFlightPlans(testData)
-  );
+  before("Add flight plans for tests", async () => await addFlightPlans(testData));
 
-  after(
-    "Remove flight plans for tests",
-    async () => await removeFlightPlans(testData)
-  );
+  after("Remove flight plans for tests", async () => await removeFlightPlans(testData));
 
   it("should not have aircraft info", async () => {
     const flightPlan = await getFlightPlan("5f9f7b3b9d3b3c1b1c9b4b51");
     expect(flightPlan.success).to.equal(true);
 
-    const result = await checkForPreferredRoutes(
-      (flightPlan as SuccessResult<IFlightPlan>).data
-    );
+    const result = await checkForPreferredRoutes((flightPlan as SuccessResult<IFlightPlan>).data);
 
     expect(result.success).to.equal(true);
 
@@ -99,9 +88,7 @@ describe("verifier: checkForPreferredRoutes tests", () => {
     const flightPlan = await getFlightPlan("5f9f7b3b9d3b3c1b1c9b4b50");
     expect(flightPlan.success).to.equal(true);
 
-    const result = await checkForPreferredRoutes(
-      (flightPlan as SuccessResult<IFlightPlan>).data
-    );
+    const result = await checkForPreferredRoutes((flightPlan as SuccessResult<IFlightPlan>).data);
 
     expect(result.success).to.equal(true);
 
@@ -115,9 +102,7 @@ describe("verifier: checkForPreferredRoutes tests", () => {
     const flightPlan = await getFlightPlan("5f9f7b3b9d3b3c1b1c9b4b52");
     expect(flightPlan.success).to.equal(true);
 
-    const result = await checkForPreferredRoutes(
-      (flightPlan as SuccessResult<IFlightPlan>).data
-    );
+    const result = await checkForPreferredRoutes((flightPlan as SuccessResult<IFlightPlan>).data);
 
     expect(result.success).to.equal(true);
 
@@ -131,9 +116,7 @@ describe("verifier: checkForPreferredRoutes tests", () => {
     const flightPlan = await getFlightPlan("5f9f7b3b9d3b3c1b1c9b4b53");
     expect(flightPlan.success).to.equal(true);
 
-    const result = await checkForPreferredRoutes(
-      (flightPlan as SuccessResult<IFlightPlan>).data
-    );
+    const result = await checkForPreferredRoutes((flightPlan as SuccessResult<IFlightPlan>).data);
 
     expect(result.success).to.equal(true);
 
@@ -147,14 +130,11 @@ describe("verifier: checkForPreferredRoutes tests", () => {
     const flightPlan = await getFlightPlan("5f9f7b3b9d3b3c1b1c9b4b54");
     expect(flightPlan.success).to.equal(true);
 
-    const result = await checkForPreferredRoutes(
-      (flightPlan as SuccessResult<IFlightPlan>).data
-    );
+    const result = await checkForPreferredRoutes((flightPlan as SuccessResult<IFlightPlan>).data);
 
     expect(result.success).to.equal(true);
 
     const data = (result as SuccessResult<IVerifierResult>).data;
-    console.log(JSON.stringify(data, null, 2));
     expect(data.status).to.equal("Error");
     expect(data.flightPlanPart).to.equal("route");
     expect(data.messageId).to.equal("notPreferredRoute");

--- a/server/test/verifiers/routeWithFlightAware.spec.mts
+++ b/server/test/verifiers/routeWithFlightAware.spec.mts
@@ -97,7 +97,6 @@ describe("verifier: routeWithFlightAware tests", () => {
     expect(result.success).to.equal(true);
 
     const data = (result as SuccessResult<IVerifierResult>).data;
-    console.log(JSON.stringify(data, null, 2));
 
     expect(data.status).to.equal("Warning");
     expect(data.flightPlanPart).to.equal("route");


### PR DESCRIPTION
Fixes #177

This is as expected, it's for airports that don't exist/to force no flight plans to be found and tested.

Took the opportunity to clean up the error logging though so there's no big call stack.