### PR TITLE
Get rid of controller ID in the add active flight plan API

### DIFF
--- a/client/src/services/activeFlightPlans.mts
+++ b/client/src/services/activeFlightPlans.mts
@@ -1,12 +1,10 @@
 import IActiveFlightPlan from "../interfaces/IActiveFlightPlan.mts";
 import http from "../utils/http.mts";
 
-const controllerId = "5f8a5fb7ebeb775e502b4e7f";
-
 export async function getActiveFlightPlans(): Promise<IActiveFlightPlan[] | undefined> {
   try {
     // Send GET request to the Express.js route using Axios
-    const response = await http.get(`activeFlightPlans/${controllerId}`, {
+    const response = await http.get(`activeFlightPlans`, {
       withCredentials: true,
       headers: {
         Authorization: `Bearer ${localStorage.getItem("token") ?? ""}`,
@@ -28,7 +26,7 @@ export async function addActiveFlightPlan(
 ): Promise<IActiveFlightPlan[] | undefined> {
   try {
     const response = await http.post(
-      `activeFlightPlans/${controllerId}/${flightPlanId}`,
+      `activeFlightPlans/${flightPlanId}`,
       {},
       {
         withCredentials: true,
@@ -52,7 +50,7 @@ export async function removeActiveFlightPlan(
   flightPlanId: string
 ): Promise<IActiveFlightPlan[] | undefined> {
   try {
-    const response = await http.delete(`activeFlightPlans/${controllerId}/${flightPlanId}`, {
+    const response = await http.delete(`activeFlightPlans/${flightPlanId}`, {
       withCredentials: true,
       headers: {
         Authorization: `Bearer ${localStorage.getItem("token") ?? ""}`,
@@ -62,9 +60,9 @@ export async function removeActiveFlightPlan(
     if (response.status === 200) {
       return response.data as IActiveFlightPlan[];
     } else {
-      throw new Error("Failed to add active flight plan");
+      throw new Error("Failed to remove active flight plan");
     }
   } catch (error) {
-    throw new Error("Failed to add active flight plan");
+    throw new Error("Failed to remove active flight plan");
   }
 }

--- a/server/src/authenticate.mts
+++ b/server/src/authenticate.mts
@@ -25,5 +25,3 @@ export const getRefreshToken = (user: any): string => {
   });
   return refreshToken;
 };
-
-export const verifyUser = passport.authenticate("jwt", { session: false });

--- a/server/src/middleware/permissions.mts
+++ b/server/src/middleware/permissions.mts
@@ -1,0 +1,9 @@
+// React router middleware for checking permissions on routes
+// based on the request type (GET, PUT, POST, DELETE, etc.)
+// and the user's permissions in the mongo database.
+
+// Import the User model
+import { Request, Response, NextFunction } from "express";
+import passport from "passport";
+
+export const verifyUser = passport.authenticate("jwt", { session: false });

--- a/server/src/routes/activeFlightPlans.mts
+++ b/server/src/routes/activeFlightPlans.mts
@@ -5,12 +5,13 @@ import {
   removeActiveFlightPlan,
   removeActiveFlightPlanByFlightPlanId,
 } from "../controllers/activeFlightPlan.mjs";
+import { verifyUser } from "../middleware/permissions.mjs";
 
 const router = express.Router();
 
 // GET route for getting all the active flight plans for a controller
-router.get("/activeFlightPlans/:controllerId", async (req: Request, res: Response) => {
-  const { controllerId } = req.params;
+router.get("/activeFlightPlans", verifyUser, async (req: Request, res: Response) => {
+  const { _id: controllerId } = req.user!;
 
   const result = await getActiveFlightPlans(controllerId);
 
@@ -26,32 +27,11 @@ router.get("/activeFlightPlans/:controllerId", async (req: Request, res: Respons
   }
 });
 
-router.post(
-  "/activeFlightPlans/:controllerId/:flightPlanId",
-  async (req: Request, res: Response) => {
-    const { controllerId, flightPlanId } = req.params;
+router.post("/activeFlightPlans/:flightPlanId", verifyUser, async (req: Request, res: Response) => {
+  const { flightPlanId } = req.params;
+  const { _id: controllerId } = req.user!;
 
-    const result = await addActiveFlightPlan(controllerId, flightPlanId);
-
-    if (result.success) {
-      res.json(result.data);
-      return;
-    }
-
-    if (result.errorType === "UnknownError") {
-      res
-        .status(404)
-        .json({ error: `Unable to add ${flightPlanId} for controller ${controllerId}.` });
-    } else {
-      res.status(500).json({ error: "Failed to add an active flight plan." });
-    }
-  }
-);
-
-router.delete("/activeFlightPlans/:id", async (req: Request, res: Response) => {
-  const { id } = req.params;
-
-  const result = await removeActiveFlightPlan(id);
+  const result = await addActiveFlightPlan(controllerId, flightPlanId);
 
   if (result.success) {
     res.json(result.data);
@@ -59,16 +39,37 @@ router.delete("/activeFlightPlans/:id", async (req: Request, res: Response) => {
   }
 
   if (result.errorType === "UnknownError") {
-    res.status(404).json({ error: `Unable to remove active flight plan ${id}` });
+    res
+      .status(404)
+      .json({ error: `Unable to add ${flightPlanId} for controller ${controllerId}.` });
+  } else {
+    res.status(500).json({ error: "Failed to add an active flight plan." });
+  }
+});
+
+router.delete("/activeFlightPlans/:id", verifyUser, async (req: Request, res: Response) => {
+  const { id: flightPlanId } = req.params;
+
+  const result = await removeActiveFlightPlan(flightPlanId);
+
+  if (result.success) {
+    res.json(result.data);
+    return;
+  }
+
+  if (result.errorType === "UnknownError") {
+    res.status(404).json({ error: `Unable to remove active flight plan ${flightPlanId}` });
   } else {
     res.status(500).json({ error: "Failed to remove an active flight plan." });
   }
 });
 
 router.delete(
-  "/activeFlightPlans/:controllerId/:flightPlanId",
+  "/activeFlightPlans/:flightPlanId",
+  verifyUser,
   async (req: Request, res: Response) => {
-    const { controllerId, flightPlanId } = req.params;
+    const { flightPlanId } = req.params;
+    const { _id: controllerId } = req.user!;
 
     const result = await removeActiveFlightPlanByFlightPlanId(controllerId, flightPlanId);
 

--- a/server/src/routes/aircraft.mts
+++ b/server/src/routes/aircraft.mts
@@ -1,10 +1,11 @@
 import express, { Request, Response } from "express";
 import { getAircraft } from "../controllers/aircraft.mjs";
+import { verifyUser } from "../middleware/permissions.mjs";
 
 const router = express.Router();
 
 // GET route for reading a flight plan from the database
-router.get("/aircraft/:id", async (req: Request, res: Response) => {
+router.get("/aircraft/:id", verifyUser, async (req: Request, res: Response) => {
   const { id } = req.params;
 
   const result = await getAircraft(id);

--- a/server/src/routes/airline.mts
+++ b/server/src/routes/airline.mts
@@ -1,10 +1,11 @@
 import express, { Request, Response } from "express";
 import { getAirline } from "../controllers/airline.mjs";
+import { verifyUser } from "../middleware/permissions.mjs";
 
 const router = express.Router();
 
 // GET route for reading a flight plan from the database
-router.get("/airline/:airlineCode", async (req: Request, res: Response) => {
+router.get("/airline/:airlineCode", verifyUser, async (req: Request, res: Response) => {
   const { airlineCode } = req.params;
 
   const result = await getAirline(airlineCode);

--- a/server/src/routes/departure.mts
+++ b/server/src/routes/departure.mts
@@ -1,10 +1,11 @@
 import express, { Request, Response } from "express";
 import { getDeparture } from "../controllers/departure.mjs";
+import { verifyUser } from "../middleware/permissions.mjs";
 
 const router = express.Router();
 
 // GET route for reading a departure from the database
-router.get("/departure/:id", async (req: Request, res: Response) => {
+router.get("/departure/:id", verifyUser, async (req: Request, res: Response) => {
   const { id } = req.params;
 
   const result = await getDeparture(id);

--- a/server/src/routes/flightAware.mts
+++ b/server/src/routes/flightAware.mts
@@ -3,10 +3,11 @@ import { getFlightAwareRoutes } from "../controllers/flightAwareRoutes.mjs";
 import IFlightPlanDocument from "../interfaces/IFlightPlanDocument.mjs";
 import { getFlightAwareAirport } from "../controllers/flightAwareAirports.mjs";
 import { IFlightAwareAirport } from "../models/FlightAwareAirport.mjs";
+import { verifyUser } from "../middleware/permissions.mjs";
 
 const router = express.Router();
 
-router.get("/flightAwareRoutes/:departure/:arrival", async (req, res) => {
+router.get("/flightAwareRoutes/:departure/:arrival", verifyUser, async (req, res) => {
   const { departure, arrival } = req.params;
 
   try {
@@ -25,7 +26,7 @@ router.get("/flightAwareRoutes/:departure/:arrival", async (req, res) => {
   }
 });
 
-router.get("/flightAwareAirport/:airportCode", async (req, res) => {
+router.get("/flightAwareAirport/:airportCode", verifyUser, async (req, res) => {
   const { airportCode } = req.params;
 
   try {

--- a/server/src/routes/flightPlan.mts
+++ b/server/src/routes/flightPlan.mts
@@ -1,11 +1,12 @@
 import express, { Request, Response } from "express";
 import IFlightPlanDocument from "../interfaces/IFlightPlanDocument.mjs";
 import { getFlightPlan, putFlightPlan } from "../controllers/flightPlans.mjs";
+import { verifyUser } from "../middleware/permissions.mjs";
 
 const router = express.Router();
 
 // POST route for storing a flight plan
-router.post("/flightPlan", async (req: Request, res: Response) => {
+router.post("/flightPlan", verifyUser, async (req: Request, res: Response) => {
   const flightPlanData: IFlightPlanDocument = req.body;
 
   const result = await putFlightPlan(flightPlanData);
@@ -18,7 +19,7 @@ router.post("/flightPlan", async (req: Request, res: Response) => {
 });
 
 // GET route for reading a flight plan from the database
-router.get("/flightPlan/:id", async (req: Request, res: Response) => {
+router.get("/flightPlan/:id", verifyUser, async (req: Request, res: Response) => {
   const { id } = req.params;
 
   const result = await getFlightPlan(id);

--- a/server/src/routes/magneticDeclination.mts
+++ b/server/src/routes/magneticDeclination.mts
@@ -1,11 +1,13 @@
 import express, { Request, Response } from "express";
 import { getMagneticDeclination } from "../controllers/magneticDeclination.mjs";
+import { verifyUser } from "../middleware/permissions.mjs";
 
 const router = express.Router();
 
 // GET route for reading a flight plan from the database
 router.get(
   "/magneticDeclination/:latitude/:longitude",
+  verifyUser,
   async (req: Request, res: Response) => {
     const { latitude, longitude } = req.params;
 

--- a/server/src/routes/preferredRoutes.mts
+++ b/server/src/routes/preferredRoutes.mts
@@ -1,11 +1,13 @@
 import express, { Request, Response } from "express";
 import { getPreferredRoutes } from "../controllers/preferredRoutes.mjs";
+import { verifyUser } from "../middleware/permissions.mjs";
 
 const router = express.Router();
 
 // GET route for reading a flight plan from the database
 router.get(
   "/preferredRoutes/:departure/:arrival",
+  verifyUser,
   async (req: Request, res: Response) => {
     const { departure, arrival } = req.params;
 

--- a/server/src/routes/user.mts
+++ b/server/src/routes/user.mts
@@ -1,10 +1,11 @@
 import express from "express";
 import passport from "passport";
 import { User } from "../models/User.mjs";
-import { getAuthToken, COOKIE_OPTIONS, getRefreshToken, verifyUser } from "../authenticate.mjs";
+import { getAuthToken, COOKIE_OPTIONS, getRefreshToken } from "../authenticate.mjs";
 import { Error as MongooseError } from "mongoose";
 import jwt, { JwtPayload } from "jsonwebtoken";
 import { ENV } from "../env.mjs";
+import { verifyUser } from "../middleware/permissions.mjs";
 
 const router = express.Router();
 

--- a/server/src/routes/verify.mts
+++ b/server/src/routes/verify.mts
@@ -21,6 +21,7 @@ import airwaysForEquipmentSuffix from "../controllers/verifiers/airwaysForEquipm
 import hasSID from "../controllers/verifiers/hasSID.mjs";
 import hasValidFirstFix from "../controllers/verifiers/hasValidFirstFix.mjs";
 import VerifierResult from "../models/VerifierResult.mjs";
+import { verifyUser } from "../middleware/permissions.mjs";
 
 const router = express.Router();
 
@@ -60,6 +61,7 @@ const verifiers: Verifier[] = [
 const handleVerifierRoute = async (routeName: string, handler: Function) => {
   router.get(
     `/verify/${routeName}/:id`,
+    verifyUser,
     findExistingResultsMiddleware(routeName),
     async (req: Request, res: Response) => {
       const { id } = req.params;
@@ -97,7 +99,7 @@ const handleVerifierRoute = async (routeName: string, handler: Function) => {
 };
 
 // Register the route to get all the results for a past run
-router.get("/verify/results/:id", async (req: Request, res: Response) => {
+router.get("/verify/results/:id", verifyUser, async (req: Request, res: Response) => {
   try {
     const rawResults = await VerifierResult.find({ flightPlanId: req.params.id });
 
@@ -128,6 +130,7 @@ router.delete("/verify/results/:id", async (req: Request, res: Response) => {
 // Register the route to run all verifiers
 router.get(
   "/verify/all/:id",
+  verifyUser,
   findExistingResultsMiddleware(),
   async (req: Request, res: Response) => {
     const { id } = req.params;


### PR DESCRIPTION
Fixes #181

This required adding `verifyUser` to all the API calls, which I clearly forgot to do when adding authentication. Oops.