### PR TITLE
Switch to using Result in loader

### DIFF
--- a/client/src/components/FlightPlan.tsx
+++ b/client/src/components/FlightPlan.tsx
@@ -17,12 +17,12 @@ import { OpenInNew } from "@mui/icons-material";
 
 interface FlightPlanProps {
   flightPlan: IFlightPlan;
-  verifierResults: IVerifyAllResult | null;
+  verifierResults: IVerifyAllResult | undefined;
 }
 
 const FlightPlan: React.FC<FlightPlanProps> = (props: FlightPlanProps) => {
   const [flightPlan, setFlightPlan] = useState<IFlightPlan>(props.flightPlan);
-  const [verifierResults, setVerifierResults] = useState<IVerifyAllResult | null>(null);
+  const [verifierResults, setVerifierResults] = useState<IVerifyAllResult | undefined>(undefined);
   const [skyVectorUrl, setSkyVectorUrl] = useState<string>("");
   const [flightAwareUrl, setFlightAwareUrl] = useState<string>("");
   const [viewAircraftUrl, setViewAircraftUrl] = useState<string>("");
@@ -75,7 +75,7 @@ const FlightPlan: React.FC<FlightPlanProps> = (props: FlightPlanProps) => {
               label="Callsign"
               name="callsign"
               inputRef={(input: HTMLInputElement) => input && input.focus()}
-              value={flightPlan.callsign}
+              value={flightPlan.callsign ?? ""}
               helperText={flightPlan?.telephony?.[0]?.telephony ?? " "}
               trim
               onPaste={parsePastedFlightPlan}
@@ -91,7 +91,7 @@ const FlightPlan: React.FC<FlightPlanProps> = (props: FlightPlanProps) => {
               id="rawAircraftType"
               label="Aircraft type"
               name="rawAircraftType"
-              value={flightPlan.rawAircraftType}
+              value={flightPlan.rawAircraftType ?? ""}
               helperText={
                 flightPlan?.equipmentInfo?.name
                   ? `${flightPlan.equipmentInfo.manufacturer} ${flightPlan.equipmentInfo.name}`
@@ -111,7 +111,7 @@ const FlightPlan: React.FC<FlightPlanProps> = (props: FlightPlanProps) => {
               id="squawk"
               label="Squawk code"
               name="squawk"
-              value={flightPlan.squawk}
+              value={flightPlan.squawk ?? ""}
               trim
               onPaste={parsePastedFlightPlan}
               onChange={(text) => {
@@ -126,7 +126,7 @@ const FlightPlan: React.FC<FlightPlanProps> = (props: FlightPlanProps) => {
               id="departure"
               label="Departure"
               name="departure"
-              value={flightPlan.departure}
+              value={flightPlan.departure ?? ""}
               helperText={
                 flightPlan?.departureAirportInfo?.name
                   ? `${normalizeAirportName(flightPlan.departureAirportInfo.name)}`
@@ -146,7 +146,7 @@ const FlightPlan: React.FC<FlightPlanProps> = (props: FlightPlanProps) => {
               id="arrival"
               label="Arrival"
               name="arrival"
-              value={flightPlan.arrival}
+              value={flightPlan.arrival ?? ""}
               helperText={
                 flightPlan?.arrivalAirportInfo?.name
                   ? `${normalizeAirportName(flightPlan.arrivalAirportInfo.name)}`
@@ -166,7 +166,7 @@ const FlightPlan: React.FC<FlightPlanProps> = (props: FlightPlanProps) => {
               id="cruiseAltitude"
               label="Cruise altitude"
               name="cruiseAltitude"
-              value={flightPlan.cruiseAltitude}
+              value={flightPlan.cruiseAltitude ?? ""}
               helperText={
                 flightPlan.initialAltitude && (
                   <>
@@ -191,7 +191,7 @@ const FlightPlan: React.FC<FlightPlanProps> = (props: FlightPlanProps) => {
               label="Route"
               name="route"
               canCopy
-              value={flightPlan.route}
+              value={flightPlan.route ?? ""}
               helperText={hyperlinkSidName(flightPlan)}
               onPaste={parsePastedFlightPlan}
               onChange={(text) => {

--- a/client/src/interfaces/IFlightPlan.mts
+++ b/client/src/interfaces/IFlightPlan.mts
@@ -5,19 +5,19 @@ import ITelephony from "./ITelephony.mts";
 
 interface IFlightPlan {
   _id?: string;
-  callsign: string;
-  rawAircraftType: string;
+  callsign?: string;
+  rawAircraftType?: string;
   equipmentCode?: string;
   equipmentInfo?: IAircraft;
-  departure: string;
-  arrival: string;
+  departure?: string;
+  arrival?: string;
   departureAirportInfo?: IFlightAwareAirport;
   arrivalAirportInfo?: IFlightAwareAirport;
-  squawk: string;
+  squawk?: string;
   isHeavy?: boolean;
   equipmentSuffix?: string;
-  cruiseAltitude: string;
-  route: string;
+  cruiseAltitude?: string;
+  route?: string;
   telephony?: ITelephony[];
   expandedRoute?: string;
   initialAltitude?: string;

--- a/client/src/pages/FlightPlanDetails.tsx
+++ b/client/src/pages/FlightPlanDetails.tsx
@@ -11,26 +11,28 @@ import AlertSnackbar, {
 } from "../components/AlertSnackbar";
 import { Paper } from "@mui/material";
 import { PlanVerifyActionResult } from "../services/flightPlanVerifyAction.mts";
-
-type LoaderProps = {
-  flightPlan: IFlightPlan;
-  verifyResults: IVerifyAllResult;
-};
+import { PlanDetailsLoaderResult } from "../services/flightPlanDetailsLoader.mts";
 
 function FlightPlanDetails() {
   const [snackbar, setSnackbar] = useState<AlertSnackbarProps>(null);
-  const { flightPlan, verifyResults } = useLoaderData() as LoaderProps;
+  const [flightPlan, setFlightPlan] = useState<IFlightPlan>({});
+  const [verifyResults, setVerifyResults] = useState<IVerifyAllResult>();
+  const loaderData = useLoaderData() as PlanDetailsLoaderResult;
   const actionData = useActionData() as PlanVerifyActionResult;
   const navigate = useNavigate();
 
   const handleSnackbarClose: AlertSnackBarOnClose = () => setSnackbar(null);
 
+  // Handles the submission response of the flight plan verification, and any
+  // errors that may have occurred.
   useEffect(() => {
     if (actionData === undefined) {
       return;
     }
 
     if (actionData.success) {
+      // This is done here instead of via redirect() in the action so the replace
+      // option can be set to stop polluting the brrwser history.
       navigate(`../${actionData.data}`, { replace: true, relative: "path" });
     } else {
       setSnackbar({
@@ -40,13 +42,34 @@ function FlightPlanDetails() {
     }
   }, [actionData, navigate]);
 
+  // Handles loading the page with data returned from the loader, and displaying
+  // any errors that may have occurred during the loading process.
   useEffect(() => {
-    if (!flightPlan.callsign) {
+    if (loaderData === undefined) {
+      return;
+    }
+
+    // Check for errors and show it in a snackbar.
+    if (!loaderData.success) {
+      setSnackbar({
+        children: loaderData.error,
+        severity: "error",
+      });
+      return;
+    }
+
+    // No errors so load the data and show it.
+    const flightPlan = loaderData.data.flightPlan;
+    setFlightPlan(loaderData.data.flightPlan ?? {});
+    setVerifyResults(loaderData.data.verifyResults);
+
+    // Set the window title to something nice if the necessary info is available.
+    if (!flightPlan.callsign || !flightPlan.departure || !flightPlan.arrival) {
       document.title = "Plan verifier";
     } else {
       document.title = `${flightPlan.callsign} (${flightPlan.departure}-${flightPlan.arrival})`;
     }
-  }, [flightPlan]);
+  }, [loaderData]);
 
   return (
     <>

--- a/client/src/utils/flightPlanParser.tsx
+++ b/client/src/utils/flightPlanParser.tsx
@@ -142,9 +142,9 @@ export function validateFlightPlan(flightPlan: IFlightPlan): boolean {
   return (
     !Number.isNaN(Number(flightPlan.squawk)) && // Callsign is a number
     !Number.isNaN(Number(flightPlan.cruiseAltitude)) && // Cruise altitude is a number
-    airportCodeRegex.test(flightPlan.departure) && // Departure airport is a valid ICAO code
-    airportCodeRegex.test(flightPlan.arrival) && // Arrival airport is a valid ICAO code
-    flightPlan.route.length > 0 // Route is not empty
+    airportCodeRegex.test(flightPlan.departure ?? "") && // Departure airport is a valid ICAO code
+    airportCodeRegex.test(flightPlan.arrival ?? "") && // Arrival airport is a valid ICAO code
+    (flightPlan.route?.length ?? 0) > 0 // Route is not empty
   );
 }
 


### PR DESCRIPTION
Fixes #467

Finally allows showing errors in the snackbar instead of crashing out to the catch-all error page