### PR TITLE
Add preferred routing warnings

### DIFF
--- a/client/src/components/VerifierResults.tsx
+++ b/client/src/components/VerifierResults.tsx
@@ -20,8 +20,12 @@ const statusOrder: Record<StatusValue, number> = {
 const VerifierResults: React.FC<VerifierResultsProps> = ({ verifierResults, flightPlan }) => {
   const filteredResults = verifierResults
     ?.filter((result) => result.status !== "Information")
-    ?.sort((a, b) => statusOrder[a.status] - statusOrder[b.status])
-    ?.sort((a, b) => a.priority - b.priority);
+    ?.sort((a, b) => {
+      if (a.status === b.status) {
+        return a.priority - b.priority;
+      }
+      return statusOrder[a.status] - statusOrder[b.status];
+    });
 
   return (
     filteredResults &&

--- a/server/src/controllers/verifiers/checkForPreferredRoutes.mts
+++ b/server/src/controllers/verifiers/checkForPreferredRoutes.mts
@@ -23,9 +23,23 @@ export default async function checkForPreferredRoutes(
   try {
     // Bail early if there's no aircraft information.
     if (!isDocument(flightPlan.equipmentInfo)) {
-      result.status = VerifierResultStatus.INFORMATION;
+      result.status = VerifierResultStatus.WARNING;
       result.messageId = "noAircraftInfoForPreferredRoute";
       result.message = `No aircraft information available for ${flightPlan.equipmentCode}, unable to check for preferred routes.`;
+      result.priority = 5;
+
+      const doc = await result.save();
+      return {
+        success: true,
+        data: doc,
+      };
+    }
+
+    // Bail early if there's no equipment suffix
+    if (!flightPlan.equipmentSuffix) {
+      result.status = VerifierResultStatus.WARNING;
+      result.messageId = "noEquipmentSuffixForPreferredRoute";
+      result.message = `No equipment suffix available for ${flightPlan.equipmentCode}, unable to check for preferred routes.`;
       result.priority = 5;
 
       const doc = await result.save();
@@ -96,7 +110,7 @@ export default async function checkForPreferredRoutes(
       data: doc,
     };
   } catch (error) {
-    logger(`Error running checkForPreferredRoutes: error`);
+    logger(`Error running checkForPreferredRoutes: ${error}`);
 
     return {
       success: false,

--- a/server/test/verifiers/checkForPreferredRoutes.spec.mts
+++ b/server/test/verifiers/checkForPreferredRoutes.spec.mts
@@ -64,6 +64,17 @@ const testData = [
     route: "PTLD2 COUGA KRIEG HAWKZ7",
     squawk: "1234",
   },
+  // No equipment suffix
+  {
+    _id: new Types.ObjectId("5f9f7b3b9d3b3c1b1c9b4b55"),
+    callsign: "ASA42",
+    departure: "KPDX",
+    arrival: "KSEA",
+    cruiseAltitude: 60,
+    rawAircraftType: "B737",
+    route: "PTLD2 COUGA KRIEG HAWKZ7",
+    squawk: "1234",
+  },
 ];
 
 describe("verifier: checkForPreferredRoutes tests", () => {
@@ -82,7 +93,7 @@ describe("verifier: checkForPreferredRoutes tests", () => {
     expect(result.success).to.equal(true);
 
     const data = (result as SuccessResult<VerifierResultDocument>).data;
-    expect(data.status).to.equal(VerifierResultStatus.INFORMATION);
+    expect(data.status).to.equal(VerifierResultStatus.WARNING);
     expect(data.flightPlanPart).to.equal("route");
     expect(data.messageId).to.equal("noAircraftInfoForPreferredRoute");
   });
@@ -149,5 +160,21 @@ describe("verifier: checkForPreferredRoutes tests", () => {
     expect(data.status).to.equal(VerifierResultStatus.ERROR);
     expect(data.flightPlanPart).to.equal("route");
     expect(data.messageId).to.equal("notPreferredRoute");
+  });
+
+  it("should warn no equipment suffix", async () => {
+    const flightPlan = await getFlightPlan("5f9f7b3b9d3b3c1b1c9b4b55");
+    expect(flightPlan.success).to.equal(true);
+
+    const result = await checkForPreferredRoutes(
+      (flightPlan as SuccessResult<FlightPlanDocument>).data
+    );
+
+    expect(result.success).to.equal(true);
+
+    const data = (result as SuccessResult<VerifierResultDocument>).data;
+    expect(data.status).to.equal(VerifierResultStatus.WARNING);
+    expect(data.flightPlanPart).to.equal("route");
+    expect(data.messageId).to.equal("noEquipmentSuffixForPreferredRoute");
   });
 });


### PR DESCRIPTION
Fixes #559 

Add warnings that display when preferred routes couldn't be looked up due to missing equipment suffix or unknown aircraft info. Also fixed the sort order of the displayed results.