### PR TITLE
Fix equipment suffixes quick reference

### DIFF
--- a/client/src/components/Markdown.tsx
+++ b/client/src/components/Markdown.tsx
@@ -18,11 +18,11 @@ const Markdown = ({ children }: MarkdownProps) => {
       children={children}
       remarkPlugins={[remarkGfm]}
       components={{
-        table: ({ children }) => <Table>{children}</Table>,
-        thead: ({ children }) => <TableHead>{children}</TableHead>,
-        tr: ({ children }) => <TableRow>{children}</TableRow>,
-        td: ({ children }) => <TableCell>{children}</TableCell>,
-        tbody: ({ children }) => <TableBody>{children}</TableBody>,
+        table: ({ children, style }) => <Table sx={{ ...style }}>{children}</Table>,
+        thead: ({ children, style }) => <TableHead sx={{ ...style }}>{children}</TableHead>,
+        tr: ({ children, style }) => <TableRow sx={{ ...style }}>{children}</TableRow>,
+        td: ({ children, style }) => <TableCell sx={{ ...style }}>{children}</TableCell>,
+        tbody: ({ children, style }) => <TableBody sx={{ ...style }}>{children}</TableBody>,
         blockquote: CustomBlockquote,
       }}
     />

--- a/server/data/quickreference/equipmentsuffixes.md
+++ b/server/data/quickreference/equipmentsuffixes.md
@@ -4,7 +4,7 @@
 | ------------ | :-----: | :---: |
 | No DME       |         |  /U   |
 | TACAN        |   /P    |       |
-| DME          |   /A    |  / W  |
+| DME          |   /A    |  /W   |
 | RNAV no GNSS |   /I    |  /Z   |
 | GNSS         |   /G    |  /L   |
 

--- a/server/scripts/add_quickreference.js
+++ b/server/scripts/add_quickreference.js
@@ -107,15 +107,15 @@ Treat as a normal aircraft.
     label: "Equipment suffixes",
     markdown: `# Equipment suffixes
 
-    |              | No RVSM | RVSM  |
-    | ------------ | :-----: | :---: |
-    | No DME       |         |  /U   |
-    | TACAN        |   /P    |       |
-    | DME          |   /A    |  / W  |
-    | RNAV no GNSS |   /I    |  /Z   |
-    | GNSS         |   /G    |  /L   |
-    
-    *Source: [FlightAware](https://flightaware.com/about/faq_aircraft_flight_plan_suffix.rvt)*
+|              | No RVSM | RVSM  |
+| ------------ | :-----: | :---: |
+| No DME       |         |  /U   |
+| TACAN        |   /P    |       |
+| DME          |   /A    |  /W   |
+| RNAV no GNSS |   /I    |  /Z   |
+| GNSS         |   /G    |  /L   |
+
+*Source: [FlightAware](https://flightaware.com/about/faq_aircraft_flight_plan_suffix.rvt)*
 `,
   },
   {


### PR DESCRIPTION
Fixes #557

* Extra spaces at the front of the lines was causing the table to not be a table
* Centering didn't work because the style wasn't getting passed through