### PR TITLE
Add an isHeavy property to Aircraft

### DIFF
--- a/server/src/models/Aircraft.mts
+++ b/server/src/models/Aircraft.mts
@@ -46,6 +46,10 @@ export class Aircraft {
   @prop({ required: false, default: false })
   isSuper!: boolean;
 
+  public get isHeavy(): boolean {
+    return this.weightClass === "H";
+  }
+
   // Finds all aircraft whose name contains the specified name
   public static async findByName(this: ReturnModelType<typeof Aircraft>, name: string) {
     return this.find({ name: { $regex: name, $options: "i" } }).exec();

--- a/server/src/models/FlightPlan.mts
+++ b/server/src/models/FlightPlan.mts
@@ -135,7 +135,7 @@ export enum VatsimCommsEnum {
       }
 
       if (rawAircraftType.startsWith("H/")) {
-        this.isHeavy = true;
+        this.rawHeavyDesignator = true;
         rawAircraftType = rawAircraftType.substring(2); // Strip off the leading "H/"
       }
 
@@ -245,7 +245,7 @@ export class FlightPlan {
   equipmentCode?: string;
 
   @prop({ required: false, default: false })
-  isHeavy!: Boolean;
+  rawHeavyDesignator!: boolean;
 
   @prop({ required: false })
   equipmentSuffix?: string;
@@ -372,6 +372,10 @@ export class FlightPlan {
     } else {
       return `${this.callsign}${this.heavyTelephony}`;
     }
+  }
+
+  public get isHeavy(): boolean {
+    return this.rawHeavyDesignator || (this.equipmentInfo as Aircraft)?.isHeavy;
   }
 
   public get isSuper(): boolean {

--- a/server/test/verifiers/warnHeavyRunwayAssignment.spec.mts
+++ b/server/test/verifiers/warnHeavyRunwayAssignment.spec.mts
@@ -53,6 +53,17 @@ const testData = [
     route: "SEA8 SEA BUWZO KRATR2",
     squawk: "1234",
   },
+  // Is heavy via DB aircract type, not H/ designator, specific runways
+  {
+    _id: new Types.ObjectId("5f9f7b3b9d3b3c1b1c9b4b4f"),
+    callsign: "ASA42",
+    departure: "KPDX",
+    arrival: "KPDX",
+    cruiseAltitude: 210,
+    rawAircraftType: "B748/L",
+    route: "SEA8 SEA BUWZO KRATR2",
+    squawk: "1234",
+  },
 ];
 
 describe("verifier: warnHeavyRunwayAssignment tests", () => {
@@ -106,6 +117,19 @@ describe("verifier: warnHeavyRunwayAssignment tests", () => {
 
   it("should warn super runway specific assignment", async function () {
     const flightPlan = await getFlightPlan("5f9f7b3b9d3b3c1b1c9b4b4e");
+    expect(flightPlan.success).to.equal(true);
+
+    const result = await warnHeavyRunwayAssignment(
+      (flightPlan as SuccessResult<FlightPlanDocument>).data
+    );
+
+    const data = (result as SuccessResult<VerifierResultDocument>).data;
+    expect(data.status).to.equal(VerifierResultStatus.WARNING);
+    expect(data.messageId).to.equal("specificHeavyRunwayAssignment");
+  });
+
+  it("should warn heav runway specific assignment, no H/", async function () {
+    const flightPlan = await getFlightPlan("5f9f7b3b9d3b3c1b1c9b4b4f");
     expect(flightPlan.success).to.equal(true);
 
     const result = await warnHeavyRunwayAssignment(


### PR DESCRIPTION
Fixes #692

The database already had a `weightClass` property that stored `H` if the plane was heavy. Add a virtual getter to the `Aircraft` class that returns true if the weightClass is H. 