### PR TITLE
Add initial climb info for Seattle departures

### DIFF
--- a/client/src/components/FlightPlan.tsx
+++ b/client/src/components/FlightPlan.tsx
@@ -4,7 +4,7 @@ import IVerifyAllResult from "../interfaces/IVerifyAllResult.mts";
 import { useEffect, useState } from "react";
 import FlightPlanTextField from "./FlightPlanTextField";
 import {
-  formattedExpectInMinutes,
+  formattedExpectIn,
   formattedInitialAltitude,
   hyperlinkSidName,
   normalizeAirportName,
@@ -195,7 +195,7 @@ const FlightPlan = (props: FlightPlanProps) => {
                   <>
                     {formattedInitialAltitude(flightPlan)}
                     <br />
-                    {formattedExpectInMinutes(flightPlan)}
+                    {formattedExpectIn(flightPlan)}
                   </>
                 )
               }

--- a/client/src/interfaces/IExtendedAirportInfo.mts
+++ b/client/src/interfaces/IExtendedAirportInfo.mts
@@ -7,5 +7,6 @@ export default interface IExtendedAirportInfo {
   initialAltitude?: number;
   initialPhrasing?: InitialPhrasingOptions;
   expectInMinutes?: number;
+  expectInMiles?: string;
   expectRequired?: boolean;
 }

--- a/client/src/interfaces/ISIDInformation.mts
+++ b/client/src/interfaces/ISIDInformation.mts
@@ -10,6 +10,7 @@ export enum InitialPhrasingOptions {
 export default interface ISIDInformation {
   InitialPhrasing: InitialPhrasingOptions;
   ExpectInMinutes?: number;
+  ExpectInMiles?: string;
   ExpectRequired?: boolean;
   Telephony?: string;
   Charts?: {

--- a/client/src/utils/flightPlanParser.tsx
+++ b/client/src/utils/flightPlanParser.tsx
@@ -82,7 +82,7 @@ export function formattedInitialAltitude(flightPlan: IFlightPlan): string {
 
 // Looks at the SIDInformation in a flight plan and returns the formatted
 // minutes after departure to expect the SID to be assigned.
-export function formattedExpectInMinutes(flightPlan: IFlightPlan): string {
+export function formattedExpectIn(flightPlan: IFlightPlan): string {
   const initialPhrasing =
     flightPlan.SIDInformation?.InitialPhrasing ??
     flightPlan.departureAirportInfo?.extendedAirportInfo?.initialPhrasing;
@@ -92,6 +92,9 @@ export function formattedExpectInMinutes(flightPlan: IFlightPlan): string {
   const expectInMinutes =
     flightPlan.SIDInformation?.ExpectInMinutes ??
     flightPlan.departureAirportInfo?.extendedAirportInfo?.expectInMinutes;
+  const expectInMiles =
+    flightPlan.SIDInformation?.ExpectInMiles ??
+    flightPlan.departureAirportInfo?.extendedAirportInfo?.expectInMiles;
 
   if (initialPhrasing === undefined || expectRequired === undefined) {
     return "";
@@ -101,8 +104,14 @@ export function formattedExpectInMinutes(flightPlan: IFlightPlan): string {
     return "";
   }
 
-  if (!expectInMinutes) {
+  if (!expectInMinutes && !expectInMiles) {
     return "See chart/SOP";
+  }
+
+  // expectInMiles takes priority if both are specified, although that should
+  // never happen
+  if (expectInMiles) {
+    return expectRequired ? expectInMiles : `(${expectInMiles})`;
   }
 
   // If the expect in minutes is required because it isn't printed on the chart

--- a/server/scripts/add_departures.js
+++ b/server/scripts/add_departures.js
@@ -843,6 +843,8 @@ db.departures.insertMany([
         AircraftClass: ".*",
       },
     ],
+    ExpectRequired: false,
+    ExpectInMiles: "15nm SEA",
     IsRNAV: true,
     ExpectRequired: false,
     ExpectInMinutes: 3,
@@ -1096,6 +1098,8 @@ db.departures.insertMany([
         AircraftClass: ".*",
       },
     ],
+    ExpectRequired: false,
+    ExpectInMiles: "15nm SEA",
     IsRNAV: true,
     Charts: {
       skyvector: "https://skyvector.com/files/tpp/2307/pdf/00582HAROB.PDF",
@@ -1196,6 +1200,8 @@ db.departures.insertMany([
       "ELN",
       "ALPSE",
     ],
+    ExpectRequired: false,
+    ExpectInMiles: "15nm SEA",
     InitialAltitudes: [
       {
         Altitude: 70,
@@ -1220,6 +1226,8 @@ db.departures.insertMany([
         AircraftClass: ".*",
       },
     ],
+    ExpectRequired: false,
+    ExpectInMiles: "15nm SEA",
     Charts: {
       skyvector: "https://skyvector.com/files/tpp/2307/pdf/00582BANGR.PDF",
     },
@@ -1247,13 +1255,15 @@ db.departures.insertMany([
       "AST",
       "HQM",
     ],
-    InitialPhrasing: "SeeNote",
+    InitialPhrasing: "Maintain",
     InitialAltitudes: [
       {
         Altitude: 70,
         AircraftClass: ".*",
       },
     ],
+    ExpectInMiles: "15nm SEA",
+    ExpectRequired: true,
     Charts: {
       skyvector: "https://skyvector.com/files/tpp/2307/pdf/00582SEATTLE.PDF",
     },

--- a/server/src/models/Departure.mts
+++ b/server/src/models/Departure.mts
@@ -37,6 +37,9 @@ export class Departure {
   @prop({ default: 0 })
   ExpectTopAltitudeInMinutes!: number;
 
+  @prop({ required: false })
+  ExpectTopAltitudeInMiles?: string;
+
   @prop({ default: false })
   IsRNAV!: boolean;
 

--- a/server/src/models/ExtendedAirportInfo.mts
+++ b/server/src/models/ExtendedAirportInfo.mts
@@ -36,6 +36,9 @@ export class ExtendedAirportInfo {
   @prop()
   expectInMinutes?: number;
 
+  @prop()
+  expectInMiles?: string;
+
   @prop({ type: () => [String] })
   heavyRunways?: string[];
 }


### PR DESCRIPTION
Fixes #717

* Adds support for `ExpectInMiles` on departures and extended airport info, which is a string property passed through for display in the client.
* Certain Seattle departures have `15nm SEA` added to the `ExpectInMiles`, which is shown as either required or optional based on the departure