### PR TITLE
Always pull data from vatsim

### DIFF
--- a/server/src/env.mts
+++ b/server/src/env.mts
@@ -16,7 +16,8 @@ const envSchema = z.object({
   API_RATE_LIMIT_MAX: z.coerce.number().default(100),
   API_RATE_LIMIT_MINUTE_WINDOW: z.coerce.number().default(5),
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
-  VATSIM_AUTO_UPDATE_INTERVAL: z.coerce.number().default(1000 * 30), // 30 seconds
+  VATSIM_CONNECTIONS_AUTO_UPDATE_INTERVAL_MS: z.coerce.number().default(1000 * 15), // 15 seconds
+  VATSIM_NO_CONNECTIONS_AUTO_UPDATE_INTERVAL_MS: z.coerce.number().default(1000 * 60), // 1 minute
   MAGNETIC_DECLINATION_CACHE_EXPIRY: z.coerce.number().default(30 * 24 * 60 * 60 * 1000), // 30 days
   AIRPORT_REFRESH_INTERVAL: z.string().default("every 24 hours"),
   VATSIM_GROUNDSPEED_CUTOFF: z.coerce.number().default(80),

--- a/server/src/services/vatsimFlightPlans.mts
+++ b/server/src/services/vatsimFlightPlans.mts
@@ -1,20 +1,19 @@
 import axios from "axios";
-import IVatsimEndpoints from "../interfaces/IVatsimEndpoints.mjs";
+import debug from "debug";
+import LatLon from "geodesy/latlon-ellipsoidal-vincenty.js";
+import _ from "lodash";
+import pluralize from "pluralize";
+import { Server as SocketIOServer } from "socket.io";
+import { getAirportInfo } from "../controllers/airportInfo.mjs";
+import { ENV } from "../env.mjs";
 import { IVatsimData, IVatsimPilot, IVatsimPrefile } from "../interfaces/IVatsimData.mjs";
+import IVatsimEndpoints from "../interfaces/IVatsimEndpoints.mjs";
 import {
   VatsimCommunicationMethod,
   VatsimFlightPlanDocument,
   VatsimFlightPlanModel,
   VatsimFlightStatus,
 } from "../models/VatsimFlightPlan.mjs";
-import debug from "debug";
-import { Server as SocketIOServer } from "socket.io";
-import pluralize from "pluralize";
-import { ENV } from "../env.mjs";
-import _ from "lodash";
-import { getAirportInfo } from "../controllers/airportInfo.mjs";
-import LatLon from "geodesy/latlon-ellipsoidal-vincenty.js";
-import { convertFLtoThousands, parseStringToNumber } from "../utils.mjs";
 import { getVatsimEndpoints } from "./vatsim.mjs";
 
 const logger = debug("plan-verifier:vatsimFlightPlans");
@@ -309,10 +308,6 @@ async function publishUpdates(io: SocketIOServer) {
 // Loads data from vatsim then processes the filed and prefiled flight plans in to the database.
 // After updating the database publishes the updated flight plan list to all connected clients.
 export async function getVatsimFlightPlans(io: SocketIOServer) {
-  if (io?.sockets.adapter.rooms.size === 0) {
-    return;
-  }
-
   logger("Fetching VATSIM flight plans...");
 
   if (!vatsimEndpoints) {


### PR DESCRIPTION
Fixes #734

* Provide new environment variables for how fast vatsim auto-updates when clients are connected vs. disconnected
* Always check for vatsim data even if clients aren't connected, just do it at the slower rate