### PR TITLE
Add a force disconnect clients endpoint

### DIFF
--- a/server/src/bree.mts
+++ b/server/src/bree.mts
@@ -1,6 +1,5 @@
 import Bree from "bree";
 import path from "path";
-import { Server as SocketIOServer } from "socket.io";
 import { fileURLToPath } from "url";
 import { ENV } from "./env.mjs";
 import mainLogger from "./logger.mjs";
@@ -43,8 +42,6 @@ jobDefinitions.set(JobName.GetVatsimTransceivers, {
     timeout: "1 minute",
   },
 });
-
-let io: SocketIOServer;
 
 async function deleteBree(jobName: JobName) {
   if (!jobDefinitions.has(jobName)) {
@@ -89,7 +86,7 @@ function createBree(jobName: JobName, interval: string): Bree | null {
     },
     workerMessageHandler: async ({ name, message }) => {
       if (message === "sendUpdates") {
-        await publishUpdates(io);
+        await publishUpdates();
       }
     },
   })
@@ -127,12 +124,10 @@ export function initialize() {
   createBree(JobName.ImportAirports, ENV.AIRPORT_INFO_AUTO_UPDATE_INTERVAL);
 }
 
-export async function start(ioInstance: SocketIOServer) {
+export async function start() {
   if (ENV.NODE_ENV === "test") {
     return;
   }
-
-  io = ioInstance;
 
   const promises = Array.from(jobDefinitions.values()).map(async (value) => {
     await value.runner?.start();

--- a/server/src/routes/endConnections.mts
+++ b/server/src/routes/endConnections.mts
@@ -1,0 +1,28 @@
+import express, { Request, Response } from "express";
+import mainLogger from "../logger.mjs";
+import { verifyUser } from "../middleware/permissions.mjs";
+import { getIO } from "../sockets/index.mjs";
+
+const logger = mainLogger.child({ service: "endConnections" });
+
+const router = express.Router();
+
+// GET route for reading a flight plan from the database
+router.get("/endConnections", verifyUser, async (req: Request, res: Response) => {
+  if (req.user?.role !== "admin") {
+    res.status(403).json({ error: "You are not authorized to access this resource." });
+    return;
+  }
+
+  let count = 0;
+  getIO().sockets.sockets.forEach((socket) => {
+    // Call disconnect() on each socket
+    socket.disconnect(true); // true parameter means the disconnect is forced
+    count++;
+  });
+
+  logger.info(`Disconnected ${count} clients`);
+  res.send(`Disconnected ${count} clients`);
+});
+
+export default router;

--- a/server/src/services/vatsim.mts
+++ b/server/src/services/vatsim.mts
@@ -6,6 +6,7 @@ import { IVatsimData } from "../interfaces/IVatsimData.mjs";
 import IVatsimEndpoints from "../interfaces/IVatsimEndpoints.mjs";
 import mainLogger from "../logger.mjs";
 import { VatsimFlightPlanModel, VatsimFlightStatus } from "../models/VatsimFlightPlan.mjs";
+import { getIO } from "../sockets/index.mjs";
 import { processVatsimATISData } from "./vatsimATIS.mjs";
 import { processVatsimFlightPlanData } from "./vatsimFlightPlans.mjs";
 
@@ -48,7 +49,6 @@ export async function getVatsimData(endpoint: string) {
         await processVatsimATISData(response.data as IVatsimData),
         await processVatsimFlightPlanData(response.data as IVatsimData),
       ]);
-      // await publishUpdates(io);
     } else {
       return {
         success: false,
@@ -66,7 +66,9 @@ export async function getVatsimData(endpoint: string) {
 }
 
 // Handles publishing updated data to all connected clients.
-export async function publishUpdates(io: SocketIOServer) {
+export async function publishUpdates() {
+  const io = getIO();
+
   if (!io) {
     logger.warn(`Unable to publish updates, no sockets defined`);
     return;

--- a/server/src/sockets/index.mts
+++ b/server/src/sockets/index.mts
@@ -9,6 +9,8 @@ import { ClientToServerEvents, ServerToClientEvents } from "../types/socketEvent
 
 const logger = mainLogger.child({ service: "sockets" });
 
+let io: SocketIOServer;
+
 // Takes an array of airport codes, converts them all to upper case, and trims whitespace
 function cleanAirportCodes(codes: string[]): string[] {
   return codes.map((code) => code.toUpperCase().trim());
@@ -103,8 +105,12 @@ async function registerForAirports(io: SocketIOServer, socket: Socket, airportCo
   publishFlightPlanUpdate(io, roomName);
 }
 
-export function setupSockets(server: Server): SocketIOServer {
-  const io = new SocketIOServer<ClientToServerEvents, ServerToClientEvents>(server, {
+export function getIO() {
+  return io;
+}
+
+export function setupSockets(server: Server) {
+  io = new SocketIOServer<ClientToServerEvents, ServerToClientEvents>(server, {
     cors: {
       origin: ENV.WHITELISTED_DOMAINS.split(","),
       credentials: true,
@@ -150,6 +156,4 @@ export function setupSockets(server: Server): SocketIOServer {
       setVatsimDataUpdateInterval(ENV.VATSIM_DATA_AUTO_UPDATE_INTERVAL_NO_CONNECTIONS);
     });
   });
-
-  return io;
 }


### PR DESCRIPTION
Fixes #853

In addition to adding the `/endConnections` endpoint clean up how sockets get used throughout the code. Instead of passing it around there's now a `getIO()` method that simply returns it. So much cleaner.