### PR TITLE
Undo delay first pull of flight plans for a minute instead of 10 seconds

### DIFF
--- a/server/src/bree.mts
+++ b/server/src/bree.mts
@@ -24,7 +24,7 @@ const jobDefinitions = new Map<JobName, Partial<JobRunner>>();
 
 jobDefinitions.set(JobName.GetVatsimData, {
   options: {
-    timeout: "1 minute",
+    timeout: "10 seconds",
   },
 });
 jobDefinitions.set(JobName.GetVatsimEndpoints, {
@@ -39,7 +39,7 @@ jobDefinitions.set(JobName.ImportAirports, {
 });
 jobDefinitions.set(JobName.GetVatsimTransceivers, {
   options: {
-    timeout: "1 minute",
+    timeout: "15 seconds",
   },
 });
 


### PR DESCRIPTION
Fixes #849

Set the delay for data to 10 seconds and transceivers to 15 seconds.