### PR TITLE
More than one bree() can get running at a time

### DIFF
--- a/server/src/sockets/index.mts
+++ b/server/src/sockets/index.mts
@@ -153,7 +153,9 @@ export function setupSockets(server: Server) {
         `Client disconnected: ${socket.id}. Total connected clients: ${io.sockets.sockets.size}`
       );
 
-      setVatsimDataUpdateInterval(ENV.VATSIM_DATA_AUTO_UPDATE_INTERVAL_NO_CONNECTIONS);
+      if (io.sockets.sockets.size === 0) {
+        setVatsimDataUpdateInterval(ENV.VATSIM_DATA_AUTO_UPDATE_INTERVAL_NO_CONNECTIONS);
+      }
     });
   });
 }


### PR DESCRIPTION
Fixes #856

* Fix bugs with the creation logic when a job is already running with the same interval
* Fix bugs with setting the interval to 1 minute when someone disconnects, instead of only when the last someone disconnects
* Switch to using add() and remove() for the jobs instead of maintaining separate brees