### PR TITLE
Treat 404 from pilot stats as a 0 hour pilot

### DIFF
--- a/server/src/controllers/verifiers/warnNewPilot.mts
+++ b/server/src/controllers/verifiers/warnNewPilot.mts
@@ -27,6 +27,11 @@ export default async function warnNewPilot({
       result.message = `Pilot stats are not available for this flight plan.`;
       result.messageId = "pilotStatsNotAvailable";
       result.priority = 3;
+    } else if (pilotStats.pilot === 0) {
+      result.status = VerifierResultStatus.WARNING;
+      result.message = `Pilot is brand new, this is their first VATSIM flight.`;
+      result.messageId = "brandNewPilot";
+      result.priority = 1;
     } else if (pilotStats.pilot < 50) {
       result.status = VerifierResultStatus.WARNING;
       result.message = `Pilot is new with only ${pluralize(

--- a/server/test/setup/addPilotStats.mts
+++ b/server/test/setup/addPilotStats.mts
@@ -52,6 +52,10 @@ const pilotStats = [
     sup: 0,
     adm: 0,
   },
+  {
+    _id: "64d816a144012e5b4de814a4",
+    cid: 1525631,
+  },
 ];
 
 export default async function setup() {

--- a/server/test/verifiers/warnNewPilot.spec.mts
+++ b/server/test/verifiers/warnNewPilot.spec.mts
@@ -45,6 +45,18 @@ const testData = [
     route: "SEA8 SEA BUWZO KRATR2",
     squawk: "1234",
   },
+  // Inexperienced pilot, first flight
+  {
+    _id: new Types.ObjectId("5f9f7b3b9d3b3c1b1c9b4b4e"),
+    cid: 1525631,
+    callsign: "ASA42",
+    departure: "KSEA",
+    arrival: "KPDX",
+    cruiseAltitude: 210,
+    rawAircraftType: "H/A388/L",
+    route: "SEA8 SEA BUWZO KRATR2",
+    squawk: "1234",
+  },
 ];
 
 describe("verifier: warnNewPilot tests", () => {
@@ -92,5 +104,19 @@ describe("verifier: warnNewPilot tests", () => {
     expect(data.status).to.equal(VerifierResultStatus.WARNING);
     expect(data.flightPlanPart).to.equal("callsign");
     expect(data.messageId).to.equal("newPilot");
+  });
+
+  it("should warn, inexperienced pilot (first flight)", async () => {
+    const flightPlan = await getFlightPlan("5f9f7b3b9d3b3c1b1c9b4b4e");
+    expect(flightPlan.success).to.equal(true);
+
+    const result = await warnNewPilot((flightPlan as SuccessResult<FlightPlanDocument>).data);
+
+    expect(result.success).to.equal(true);
+
+    const data = (result as SuccessResult<VerifierResultDocument>).data;
+    expect(data.status).to.equal(VerifierResultStatus.WARNING);
+    expect(data.flightPlanPart).to.equal("callsign");
+    expect(data.messageId).to.equal("brandNewPilot");
   });
 });


### PR DESCRIPTION
Fixes #861

* Treats the 404 as a 0 hour pilot
* Updates the warning for new pilots to have a dedicated message for 0 hour pilots