### PR TITLE
Improve performance of verifyAll

### DIFF
--- a/server/.vscode/verifier.code-snippets
+++ b/server/.vscode/verifier.code-snippets
@@ -108,10 +108,10 @@
       "const verifierName = \"${TM_FILENAME_BASE}\""
       "const logger = mainLogger.child({ service: verifierName });",
       ""
-      "export default async function ${TM_FILENAME_BASE}({",
+      "const ${TM_FILENAME_BASE}: VerifierFunction = async function({",
       "  _id,",
       "  equipmentSuffix,",
-      "}: FlightPlan): Promise<VerifierControllerResult> {",
+      "}, saveResult = true) {",
       "  // Set up the default result for a successful run of the verifier.",
       "  let result: VerifierControllerResult = {",
       "    success: true,",
@@ -134,20 +134,23 @@
       "      result.data.message = ``;",
       "    }",
       "",
-      "    await result.data.save();",
+      "    if (saveResult) {",
+      "      await result.data.save();",
+      "    }"
+      "    return result;"
       "  } catch (err) {",
       "    const error = err as Error;"
       "    logger.error(`Error running ${TM_FILENAME_BASE}: ${error.message}`, error);",
       "",
-      "    result = {",
+      "    return {",
       "      success: false,",
       "      errorType: \"UnknownError\",",
       "      error: `Error running ${TM_FILENAME_BASE}: ${error.message}`,",
       "    };",
       "  }",
-      "",
-      "  return result;",
       "}",
+      ""
+      "export default  ${TM_FILENAME_BASE};"
       ""
     ],
     "description": "Create a verifier"

--- a/server/src/controllers/verifiers/airwaysForEquipmentSuffix.mts
+++ b/server/src/controllers/verifiers/airwaysForEquipmentSuffix.mts
@@ -9,9 +9,9 @@ const logger = mainLogger.child({ service: verifierName });
 const airwaysForEquipmentSuffix: VerifierFunction = async function (
   { _id, equipmentSuffix, isGNSSCapable, isRNAVCapable, routeParts },
   saveResult = true
-): Promise<VerifierControllerResult> {
+) {
   // Set up the default result for a successful run of the verifier.
-  let result = new VerifierResultModel({
+  const result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "route",
@@ -66,7 +66,7 @@ const airwaysForEquipmentSuffix: VerifierFunction = async function (
     }
 
     if (saveResult) {
-      result = await result.save();
+      await result.save();
     }
 
     return {

--- a/server/src/controllers/verifiers/airwaysForEquipmentSuffix.mts
+++ b/server/src/controllers/verifiers/airwaysForEquipmentSuffix.mts
@@ -1,20 +1,17 @@
 import mainLogger from "../../logger.mjs";
-import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "airwaysForEquipmentSuffix";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function airwaysForEquipmentSuffix({
-  _id,
-  equipmentSuffix,
-  isGNSSCapable,
-  isRNAVCapable,
-  routeParts,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const airwaysForEquipmentSuffix: VerifierFunction = async function (
+  { _id, equipmentSuffix, isGNSSCapable, isRNAVCapable, routeParts },
+  saveResult = true
+): Promise<VerifierControllerResult> {
   // Set up the default result for a successful run of the verifier.
-  const result = new VerifierResultModel({
+  let result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "route",
@@ -68,10 +65,13 @@ export default async function airwaysForEquipmentSuffix({
       result.priority = 5;
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      result = await result.save();
+    }
+
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -84,4 +84,6 @@ export default async function airwaysForEquipmentSuffix({
       error: `Error running airwaysForEquipmentSuffix: ${error.message}`,
     };
   }
-}
+};
+
+export default airwaysForEquipmentSuffix;

--- a/server/src/controllers/verifiers/allVerifiers.mts
+++ b/server/src/controllers/verifiers/allVerifiers.mts
@@ -1,0 +1,62 @@
+import { Verifier } from "../../types/verifier.mjs";
+
+import airwaysForEquipmentSuffix from "./airwaysForEquipmentSuffix.mjs";
+import altitudeForAltimeter from "./altitudeForAltimeter.mjs";
+import altitudeForDirectionOfFlight from "./altitudeForDirectionOfFlight.mjs";
+import checkEquipmentSuffixAgainstKnown from "./checkEquipmentSuffixAgainstKnown.mjs";
+import checkForCustomAirportMessages from "./checkForCustomAirportMessages.mjs";
+import checkForCustomDepartureMessages from "./checkForCustomDepartureMessages.mjs";
+import checkForGroundRestrictions from "./checkForGroundRestrictions.mjs";
+import checkForNonStandardEquipmentSuffix from "./checkForNonStandardEquipmentSuffix.mjs";
+import checkForPreferredRoutes from "./checkForPreferredRoutes.mjs";
+import checkKPDXtoKSLEAltitude from "./checkKPDXtoKSLEAltitude.mjs";
+import checkSEAInitialSID from "./checkSEAInitialSID.mjs";
+import departureForLocalTime from "./departureForLocalTime.mjs";
+import hasEquipmentSuffix from "./hasEquipmentSuffix.mjs";
+import hasSID from "./hasSID.mjs";
+import hasValidFirstFix from "./hasValidFirstFix.mjs";
+import jetIsNotSlantA from "./jetIsNotSlantA.mjs";
+import nonRNAVHasAirways from "./nonRNAVHasAirways.mjs";
+import nonRVSMIsBelow290 from "./nonRVSMIsBelow290.mjs";
+import pistonNotSlantLorZ from "./pistonNotSlantLorZ.mjs";
+import routeWithFlightAware from "./routeWithFlightAware.mjs";
+import validArrivalAirport from "./validArrivalAirport.mjs";
+import validDepartureAirport from "./validDepartureAirport.mjs";
+import warnHeavyRunwayAssignment from "./warnHeavyRunwayAssignment.mjs";
+import warnNewPilot from "./warnNewPilot.mjs";
+import warnTextOnlyPilot from "./warnTextOnlyPilot.mjs";
+
+// List of verifiers to support
+export const verifiers: Verifier[] = [
+  { name: "checkForCustomAirportMessages", handler: checkForCustomAirportMessages },
+  { name: "checkForCustomDepartureMessages", handler: checkForCustomDepartureMessages },
+  { name: "hasEquipmentSuffix", handler: hasEquipmentSuffix },
+  { name: "warnHeavyRunwayAssignment", handler: warnHeavyRunwayAssignment },
+  {
+    name: "altitudeForDirectionOfFlight",
+    handler: altitudeForDirectionOfFlight,
+  },
+  {
+    name: "checkEquipmentSuffixAgainstKnown",
+    handler: checkEquipmentSuffixAgainstKnown,
+  },
+  { name: "routeWithFlightAware", handler: routeWithFlightAware },
+  { name: "checkForPreferredRoutes", handler: checkForPreferredRoutes },
+  { name: "nonRVSMIsBelow290", handler: nonRVSMIsBelow290 },
+  { name: "jetIsNotSlantA", handler: jetIsNotSlantA },
+  { name: "nonRNAVHasAirways", handler: nonRNAVHasAirways },
+  { name: "validDepartureAirport", handler: validDepartureAirport },
+  { name: "validArrivalAirport", handler: validArrivalAirport },
+  { name: "checkForNonStandardEquipmentSuffix", handler: checkForNonStandardEquipmentSuffix },
+  { name: "airwaysForEquipmentSuffix", handler: airwaysForEquipmentSuffix },
+  { name: "hasSID", handler: hasSID },
+  { name: "hasValidFirstFix", handler: hasValidFirstFix },
+  { name: "pistonNotSlantLorZ", handler: pistonNotSlantLorZ },
+  { name: "checkKPDXtoKSLEAltitude", handler: checkKPDXtoKSLEAltitude },
+  { name: "warnNewPilot", handler: warnNewPilot },
+  { name: "altitudeForAltimeter", handler: altitudeForAltimeter },
+  { name: "warnTextOnlyPilot", handler: warnTextOnlyPilot },
+  { name: "departureForLocalTime", handler: departureForLocalTime },
+  { name: "checkForGroundRestrictions", handler: checkForGroundRestrictions },
+  { name: "checkSEAInitialSID", handler: checkSEAInitialSID },
+];

--- a/server/src/controllers/verifiers/altitudeForAltimeter.mts
+++ b/server/src/controllers/verifiers/altitudeForAltimeter.mts
@@ -10,7 +10,7 @@ const logger = mainLogger.child({ service: verifierName });
 const altitudeForAltimeter: VerifierFunction = async function (
   { _id, departure, cruiseAltitude, cruiseAltitudeFormatted },
   saveResult = true
-): Promise<VerifierControllerResult> {
+) {
   // Set up the default result for a successful run of the verifier.
   let result: VerifierControllerResult = {
     success: true,

--- a/server/src/controllers/verifiers/altitudeForAltimeter.mts
+++ b/server/src/controllers/verifiers/altitudeForAltimeter.mts
@@ -1,18 +1,16 @@
 import mainLogger from "../../logger.mjs";
-import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 import { getMetar } from "../metar.mjs";
 
 const verifierName = "altitudeForAltimeter";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function altitudeForAltimeter({
-  _id,
-  departure,
-  cruiseAltitude,
-  cruiseAltitudeFormatted,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const altitudeForAltimeter: VerifierFunction = async function (
+  { _id, departure, cruiseAltitude, cruiseAltitudeFormatted },
+  saveResult = true
+): Promise<VerifierControllerResult> {
   // Set up the default result for a successful run of the verifier.
   let result: VerifierControllerResult = {
     success: true,
@@ -68,7 +66,10 @@ export default async function altitudeForAltimeter({
       result.data.priority = 5;
       result.data.messageId = "AltitudeOk";
     }
-    await result.data.save();
+
+    if (saveResult) {
+      await result.data.save();
+    }
   } catch (err) {
     const error = err as Error;
 
@@ -82,4 +83,6 @@ export default async function altitudeForAltimeter({
   }
 
   return result;
-}
+};
+
+export default altitudeForAltimeter;

--- a/server/src/controllers/verifiers/altitudeForDirectionOfFlight.mts
+++ b/server/src/controllers/verifiers/altitudeForDirectionOfFlight.mts
@@ -1,6 +1,6 @@
 import mainLogger from "../../logger.mjs";
-import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 import { formatAltitude } from "../../utils.mjs";
 
@@ -10,16 +10,12 @@ const logger = mainLogger.child({ service: verifierName });
 const eastboundRVSMAltitudes: number[] = [450, 490, 530, 570];
 const westboundRVSMAltiudes: number[] = [430, 470, 510, 550, 590];
 
-export default async function altitudeForDirectionOfFlight({
-  _id,
-  directionOfFlight,
-  cruiseAltitude,
-  cruiseAltitudeFormatted,
-  departure,
-  arrival,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const altitudeForDirectionOfFlight: VerifierFunction = async function (
+  { _id, directionOfFlight, cruiseAltitude, cruiseAltitudeFormatted, departure, arrival },
+  saveResult = true
+): Promise<VerifierControllerResult> {
   // Set up the default result for a successful run of the verifier.
-  const result = new VerifierResultModel({
+  let result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "cruiseAltitude",
@@ -93,11 +89,13 @@ export default async function altitudeForDirectionOfFlight({
       }
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      result = await result.save();
+    }
 
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -110,4 +108,6 @@ export default async function altitudeForDirectionOfFlight({
       error: `Error running ${verifierName}: ${error.message}`,
     };
   }
-}
+};
+
+export default altitudeForDirectionOfFlight;

--- a/server/src/controllers/verifiers/altitudeForDirectionOfFlight.mts
+++ b/server/src/controllers/verifiers/altitudeForDirectionOfFlight.mts
@@ -13,9 +13,9 @@ const westboundRVSMAltiudes: number[] = [430, 470, 510, 550, 590];
 const altitudeForDirectionOfFlight: VerifierFunction = async function (
   { _id, directionOfFlight, cruiseAltitude, cruiseAltitudeFormatted, departure, arrival },
   saveResult = true
-): Promise<VerifierControllerResult> {
+) {
   // Set up the default result for a successful run of the verifier.
-  let result = new VerifierResultModel({
+  const result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "cruiseAltitude",
@@ -90,7 +90,7 @@ const altitudeForDirectionOfFlight: VerifierFunction = async function (
     }
 
     if (saveResult) {
-      result = await result.save();
+      await result.save();
     }
 
     return {

--- a/server/src/controllers/verifiers/checkEquipmentSuffixAgainstKnown.mts
+++ b/server/src/controllers/verifiers/checkEquipmentSuffixAgainstKnown.mts
@@ -1,20 +1,18 @@
 import { isDocument } from "@typegoose/typegoose";
 import mainLogger from "../../logger.mjs";
-import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "checkEquipmentSuffixAgainstKnown";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function checkEquipmentSuffixAgainstKnown({
-  _id,
-  equipmentInfo,
-  equipmentSuffix,
-  equipmentCode,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const checkEquipmentSuffixAgainstKnown: VerifierFunction = async function (
+  { _id, equipmentInfo, equipmentSuffix, equipmentCode },
+  saveResult = true
+): Promise<VerifierControllerResult> {
   // Set up the default result for a successful run of the verifier.
-  const result = new VerifierResultModel({
+  let result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "rawAircraftType",
@@ -60,10 +58,13 @@ export default async function checkEquipmentSuffixAgainstKnown({
       result.message = `Equipment suffix ${equipmentSuffix} matches an expected suffix for ${equipmentCode}.`;
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      result = await result.save();
+    }
+
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -76,4 +77,6 @@ export default async function checkEquipmentSuffixAgainstKnown({
       error: `Error running ${verifierName}: ${error.message}`,
     };
   }
-}
+};
+
+export default checkEquipmentSuffixAgainstKnown;

--- a/server/src/controllers/verifiers/checkEquipmentSuffixAgainstKnown.mts
+++ b/server/src/controllers/verifiers/checkEquipmentSuffixAgainstKnown.mts
@@ -2,7 +2,6 @@ import { isDocument } from "@typegoose/typegoose";
 import mainLogger from "../../logger.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
 import { VerifierFunction } from "../../types/verifier.mjs";
-import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "checkEquipmentSuffixAgainstKnown";
 const logger = mainLogger.child({ service: verifierName });
@@ -10,9 +9,9 @@ const logger = mainLogger.child({ service: verifierName });
 const checkEquipmentSuffixAgainstKnown: VerifierFunction = async function (
   { _id, equipmentInfo, equipmentSuffix, equipmentCode },
   saveResult = true
-): Promise<VerifierControllerResult> {
+) {
   // Set up the default result for a successful run of the verifier.
-  let result = new VerifierResultModel({
+  const result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "rawAircraftType",
@@ -59,7 +58,7 @@ const checkEquipmentSuffixAgainstKnown: VerifierFunction = async function (
     }
 
     if (saveResult) {
-      result = await result.save();
+      await result.save();
     }
 
     return {

--- a/server/src/controllers/verifiers/checkForCustomAirportMessages.mts
+++ b/server/src/controllers/verifiers/checkForCustomAirportMessages.mts
@@ -1,19 +1,21 @@
 import mainLogger from "../../logger.mjs";
 import { CustomMessageModel, MessageTarget } from "../../models/CustomMessages.mjs";
-import { FlightPlan } from "../../models/FlightPlan.mjs";
 import {
   VerifierResultDocument,
   VerifierResultModel,
   VerifierResultStatus,
 } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import { VerifierControllerMultiResult } from "../../types/verifierControllerResult.mjs";
+import { logMongoBulkErrors } from "../../utils.mjs";
 import applyMustacheValues from "../../utils/mustache.mjs";
 
 const verifierName = "checkForCustomAirportMessages";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function checkForCustomAirportMessages(
-  flightPlan: FlightPlan
+const checkForCustomAirportMessages: VerifierFunction = async function (
+  flightPlan,
+  saveResult = true
 ): Promise<VerifierControllerMultiResult> {
   // Set up the default result for a successful run of the verifier.
   let results: VerifierResultDocument[] = [];
@@ -54,12 +56,13 @@ export default async function checkForCustomAirportMessages(
       );
     }
 
-    // Save all the results
-    await Promise.all(
-      results.map(async (result) => {
-        await result.save();
-      })
-    );
+    if (saveResult) {
+      try {
+        await VerifierResultModel.bulkSave(results);
+      } catch (err) {
+        logMongoBulkErrors(logger, err);
+      }
+    }
 
     // Return all the results
     return {
@@ -77,4 +80,6 @@ export default async function checkForCustomAirportMessages(
       error: `Error running checkForCustomAirportMessages: ${error.message}`,
     };
   }
-}
+};
+
+export default checkForCustomAirportMessages;

--- a/server/src/controllers/verifiers/checkForCustomAirportMessages.mts
+++ b/server/src/controllers/verifiers/checkForCustomAirportMessages.mts
@@ -6,7 +6,6 @@ import {
   VerifierResultStatus,
 } from "../../models/VerifierResult.mjs";
 import { VerifierFunction } from "../../types/verifier.mjs";
-import { VerifierControllerMultiResult } from "../../types/verifierControllerResult.mjs";
 import { logMongoBulkErrors } from "../../utils.mjs";
 import applyMustacheValues from "../../utils/mustache.mjs";
 
@@ -16,7 +15,7 @@ const logger = mainLogger.child({ service: verifierName });
 const checkForCustomAirportMessages: VerifierFunction = async function (
   flightPlan,
   saveResult = true
-): Promise<VerifierControllerMultiResult> {
+) {
   // Set up the default result for a successful run of the verifier.
   let results: VerifierResultDocument[] = [];
 

--- a/server/src/controllers/verifiers/checkForCustomDepartureMessages.mts
+++ b/server/src/controllers/verifiers/checkForCustomDepartureMessages.mts
@@ -6,7 +6,6 @@ import {
   VerifierResultStatus,
 } from "../../models/VerifierResult.mjs";
 import { VerifierFunction } from "../../types/verifier.mjs";
-import { VerifierControllerMultiResult } from "../../types/verifierControllerResult.mjs";
 import { logMongoBulkErrors } from "../../utils.mjs";
 import applyMustacheValues from "../../utils/mustache.mjs";
 
@@ -16,7 +15,7 @@ const logger = mainLogger.child({ service: verifierName });
 const checkForCustomDepartureMessages: VerifierFunction = async function (
   flightPlan,
   saveResult = true
-): Promise<VerifierControllerMultiResult> {
+) {
   // Set up the default result for a successful run of the verifier.
   let results: VerifierResultDocument[] = [];
 

--- a/server/src/controllers/verifiers/checkForCustomDepartureMessages.mts
+++ b/server/src/controllers/verifiers/checkForCustomDepartureMessages.mts
@@ -1,19 +1,21 @@
 import mainLogger from "../../logger.mjs";
 import { CustomMessageModel, MessageTarget } from "../../models/CustomMessages.mjs";
-import { FlightPlan } from "../../models/FlightPlan.mjs";
 import {
   VerifierResultDocument,
   VerifierResultModel,
   VerifierResultStatus,
 } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import { VerifierControllerMultiResult } from "../../types/verifierControllerResult.mjs";
+import { logMongoBulkErrors } from "../../utils.mjs";
 import applyMustacheValues from "../../utils/mustache.mjs";
 
 const verifierName = "checkForCustomDepartureMessages";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function checkForCustomDepartureMessages(
-  flightPlan: FlightPlan
+const checkForCustomDepartureMessages: VerifierFunction = async function (
+  flightPlan,
+  saveResult = true
 ): Promise<VerifierControllerMultiResult> {
   // Set up the default result for a successful run of the verifier.
   let results: VerifierResultDocument[] = [];
@@ -69,12 +71,13 @@ export default async function checkForCustomDepartureMessages(
       }
     }
 
-    // Save all the results
-    await Promise.all(
-      results.map(async (result) => {
-        await result.save();
-      })
-    );
+    if (saveResult) {
+      try {
+        await VerifierResultModel.bulkSave(results);
+      } catch (err) {
+        logMongoBulkErrors(logger, err);
+      }
+    }
 
     // Return all the results
     return {
@@ -92,4 +95,6 @@ export default async function checkForCustomDepartureMessages(
       error: `Error running checkForCustomDepartureMessages: ${error.message}`,
     };
   }
-}
+};
+
+export default checkForCustomDepartureMessages;

--- a/server/src/controllers/verifiers/checkForGroundRestrictions.mts
+++ b/server/src/controllers/verifiers/checkForGroundRestrictions.mts
@@ -7,7 +7,6 @@ import {
   VerifierResultStatus,
 } from "../../models/VerifierResult.mjs";
 import { VerifierFunction } from "../../types/verifier.mjs";
-import { VerifierControllerMultiResult } from "../../types/verifierControllerResult.mjs";
 import { logMongoBulkErrors } from "../../utils.mjs";
 import applyMustacheValues from "../../utils/mustache.mjs";
 
@@ -17,7 +16,7 @@ const logger = mainLogger.child({ service: verifierName });
 const checkForGroundRestrictions: VerifierFunction = async function (
   flightPlan,
   saveResult = true
-): Promise<VerifierControllerMultiResult> {
+) {
   // Set up the default result for a successful run of the verifier.
   let results: VerifierResultDocument[] = [];
 

--- a/server/src/controllers/verifiers/checkForNonStandardEquipmentSuffix.mts
+++ b/server/src/controllers/verifiers/checkForNonStandardEquipmentSuffix.mts
@@ -1,17 +1,17 @@
 import mainLogger from "../../logger.mjs";
-import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "checkForNonStandardEquipmentSuffix";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function checkForNonStandardEquipmentSuffix({
-  _id,
-  equipmentSuffix,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const checkForNonStandardEquipmentSuffix: VerifierFunction = async function (
+  { _id, equipmentSuffix },
+  saveResult = true
+): Promise<VerifierControllerResult> {
   // Set up the default result for a successful run of the verifier.
-  const result = new VerifierResultModel({
+  let result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "rawAircraftType",
@@ -44,10 +44,13 @@ export default async function checkForNonStandardEquipmentSuffix({
       result.priority = 5;
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      result = await result.save();
+    }
+
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -60,4 +63,6 @@ export default async function checkForNonStandardEquipmentSuffix({
       error: `Error running checkForNonStandardEquipmentSuffix: ${error.message}`,
     };
   }
-}
+};
+
+export default checkForNonStandardEquipmentSuffix;

--- a/server/src/controllers/verifiers/checkForNonStandardEquipmentSuffix.mts
+++ b/server/src/controllers/verifiers/checkForNonStandardEquipmentSuffix.mts
@@ -9,9 +9,9 @@ const logger = mainLogger.child({ service: verifierName });
 const checkForNonStandardEquipmentSuffix: VerifierFunction = async function (
   { _id, equipmentSuffix },
   saveResult = true
-): Promise<VerifierControllerResult> {
+) {
   // Set up the default result for a successful run of the verifier.
-  let result = new VerifierResultModel({
+  const result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "rawAircraftType",
@@ -45,7 +45,7 @@ const checkForNonStandardEquipmentSuffix: VerifierFunction = async function (
     }
 
     if (saveResult) {
-      result = await result.save();
+      await result.save();
     }
 
     return {

--- a/server/src/controllers/verifiers/checkForPreferredRoutes.mts
+++ b/server/src/controllers/verifiers/checkForPreferredRoutes.mts
@@ -10,12 +10,9 @@ import { formatAltitude } from "../../utils.mjs";
 const verifierName = "checkForPreferredRoutes";
 const logger = mainLogger.child({ service: verifierName });
 
-const checkForPreferredRoutes: VerifierFunction = async function (
-  flightPlan,
-  saveResult = true
-): Promise<VerifierControllerResult> {
+const checkForPreferredRoutes: VerifierFunction = async function (flightPlan, saveResult = true) {
   // Set up the default result for a successful run of the verifier.
-  let result = new VerifierResultModel({
+  const result = new VerifierResultModel({
     flightPlanId: flightPlan._id,
     verifier: verifierName,
     flightPlanPart: "route",
@@ -108,7 +105,7 @@ const checkForPreferredRoutes: VerifierFunction = async function (
     }
 
     if (saveResult) {
-      result = await result.save();
+      await result.save();
     }
     return {
       success: true,

--- a/server/src/controllers/verifiers/checkKPDXtoKSLEAltitude.mts
+++ b/server/src/controllers/verifiers/checkKPDXtoKSLEAltitude.mts
@@ -10,9 +10,9 @@ const logger = mainLogger.child({ service: verifierName });
 const checkKPDXtoKSLEAltitude: VerifierFunction = async function (
   { _id, departure, arrival, cruiseAltitude },
   saveResult = true
-): Promise<VerifierControllerResult> {
+) {
   // Set up the default result for a successful run of the verifier.
-  let result = new VerifierResultModel({
+  const result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "cruiseAltitude",
@@ -52,7 +52,7 @@ const checkKPDXtoKSLEAltitude: VerifierFunction = async function (
     }
 
     if (saveResult) {
-      result = await result.save();
+      await result.save();
     }
     return {
       success: true,

--- a/server/src/controllers/verifiers/checkKPDXtoKSLEAltitude.mts
+++ b/server/src/controllers/verifiers/checkKPDXtoKSLEAltitude.mts
@@ -1,20 +1,18 @@
 import mainLogger from "../../logger.mjs";
-import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 import { formatAltitude } from "../../utils.mjs";
 
 const verifierName = "checkKPDXtoKSLEAltitude";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function checkKPDXtoKSLEAltitude({
-  _id,
-  departure,
-  arrival,
-  cruiseAltitude,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const checkKPDXtoKSLEAltitude: VerifierFunction = async function (
+  { _id, departure, arrival, cruiseAltitude },
+  saveResult = true
+): Promise<VerifierControllerResult> {
   // Set up the default result for a successful run of the verifier.
-  const result = new VerifierResultModel({
+  let result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "cruiseAltitude",
@@ -53,10 +51,12 @@ export default async function checkKPDXtoKSLEAltitude({
       result.priority = 3;
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      result = await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -69,4 +69,6 @@ export default async function checkKPDXtoKSLEAltitude({
       error: `Error running checkKPDXtoKSLEAltitude: ${error.message}`,
     };
   }
-}
+};
+
+export default checkKPDXtoKSLEAltitude;

--- a/server/src/controllers/verifiers/checkSEAInitialSID.mts
+++ b/server/src/controllers/verifiers/checkSEAInitialSID.mts
@@ -187,10 +187,7 @@ export function calculateInitialSIDForNotJets(flightPlan: FlightPlan): InitialSi
   return calculateInitialSidAllGroups(flightPlan);
 }
 
-const checkSEAInitialSID: VerifierFunction = async function (
-  flightPlan,
-  saveResult = true
-): Promise<VerifierControllerResult> {
+const checkSEAInitialSID: VerifierFunction = async function (flightPlan, saveResult = true) {
   // Set up the default result for a successful run of the verifier.
   let result: VerifierControllerResult = {
     success: true,

--- a/server/src/controllers/verifiers/checkSEAInitialSID.mts
+++ b/server/src/controllers/verifiers/checkSEAInitialSID.mts
@@ -5,6 +5,7 @@ import { AircraftDocument } from "../../models/Aircraft.mjs";
 import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { AirportFlow } from "../../models/InitialAltitude.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "checkSEAInitialSID";
@@ -186,8 +187,9 @@ export function calculateInitialSIDForNotJets(flightPlan: FlightPlan): InitialSi
   return calculateInitialSidAllGroups(flightPlan);
 }
 
-export default async function checkSEAInitialSID(
-  flightPlan: FlightPlan
+const checkSEAInitialSID: VerifierFunction = async function (
+  flightPlan,
+  saveResult = true
 ): Promise<VerifierControllerResult> {
   // Set up the default result for a successful run of the verifier.
   let result: VerifierControllerResult = {
@@ -266,7 +268,9 @@ export default async function checkSEAInitialSID(
       result.data.messageId = "correctKSEASID";
     }
 
-    await result.data.save();
+    if (saveResult) {
+      await result.data.save();
+    }
   } catch (err) {
     const error = err as Error;
 
@@ -280,4 +284,6 @@ export default async function checkSEAInitialSID(
   }
 
   return result;
-}
+};
+
+export default checkSEAInitialSID;

--- a/server/src/controllers/verifiers/departureForLocalTime.mts
+++ b/server/src/controllers/verifiers/departureForLocalTime.mts
@@ -10,7 +10,7 @@ const logger = mainLogger.child({ service: verifierName });
 const departureForLocalTime: VerifierFunction = async function (
   { _id, SIDInformation, SID },
   saveResult = true
-): Promise<VerifierControllerResult> {
+) {
   // Set up the default result for a successful run of the verifier.
   let result: VerifierControllerResult = {
     success: true,

--- a/server/src/controllers/verifiers/departureForLocalTime.mts
+++ b/server/src/controllers/verifiers/departureForLocalTime.mts
@@ -1,17 +1,16 @@
 import { isDocument } from "@typegoose/typegoose";
 import mainLogger from "../../logger.mjs";
-import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "departureForLocalTime";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function departureForLocalTime({
-  _id,
-  SIDInformation,
-  SID,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const departureForLocalTime: VerifierFunction = async function (
+  { _id, SIDInformation, SID },
+  saveResult = true
+): Promise<VerifierControllerResult> {
   // Set up the default result for a successful run of the verifier.
   let result: VerifierControllerResult = {
     success: true,
@@ -55,7 +54,9 @@ export default async function departureForLocalTime({
       }
     }
 
-    await result.data.save();
+    if (saveResult) {
+      await result.data.save();
+    }
   } catch (err) {
     const error = err as Error;
 
@@ -69,4 +70,6 @@ export default async function departureForLocalTime({
   }
 
   return result;
-}
+};
+
+export default departureForLocalTime;

--- a/server/src/controllers/verifiers/hasEquipmentSuffix.mts
+++ b/server/src/controllers/verifiers/hasEquipmentSuffix.mts
@@ -10,9 +10,9 @@ const logger = mainLogger.child({ service: verifierName });
 const hasEquipmentSuffix: VerifierFunction = async function (
   { _id, equipmentSuffix, equipmentInfo },
   saveResult = true
-): Promise<VerifierControllerResult> {
+) {
   // Set up the default result for a successful run of the verifier.
-  let result = new VerifierResultModel({
+  const result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "rawAircraftType",
@@ -43,7 +43,7 @@ const hasEquipmentSuffix: VerifierFunction = async function (
     }
 
     if (saveResult) {
-      result = await result.save();
+      await result.save();
     }
     return {
       success: true,

--- a/server/src/controllers/verifiers/hasEquipmentSuffix.mts
+++ b/server/src/controllers/verifiers/hasEquipmentSuffix.mts
@@ -1,19 +1,18 @@
 import { isDocument } from "@typegoose/typegoose";
 import mainLogger from "../../logger.mjs";
-import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "hasEquipmentSuffix";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function hasEquipmentSuffix({
-  _id,
-  equipmentSuffix,
-  equipmentInfo,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const hasEquipmentSuffix: VerifierFunction = async function (
+  { _id, equipmentSuffix, equipmentInfo },
+  saveResult = true
+): Promise<VerifierControllerResult> {
   // Set up the default result for a successful run of the verifier.
-  const result = new VerifierResultModel({
+  let result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "rawAircraftType",
@@ -43,10 +42,12 @@ export default async function hasEquipmentSuffix({
       result.message = `Flight plan has an equipment suffix.`;
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      result = await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -59,4 +60,6 @@ export default async function hasEquipmentSuffix({
       error: `Error running hasEquipmentSuffix: ${error.message}`,
     };
   }
-}
+};
+
+export default hasEquipmentSuffix;

--- a/server/src/controllers/verifiers/hasSID.mts
+++ b/server/src/controllers/verifiers/hasSID.mts
@@ -10,9 +10,9 @@ const logger = mainLogger.child({ service: verifierName });
 const hasSID: VerifierFunction = async function (
   { _id, SID, departureAirportInfo },
   saveResult = true
-): Promise<VerifierControllerResult> {
+) {
   // Set up the default result for a successful run of the verifier.
-  let result = new VerifierResultModel({
+  const result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "route",
@@ -43,7 +43,7 @@ const hasSID: VerifierFunction = async function (
     }
 
     if (saveResult) {
-      result = await result.save();
+      await result.save();
     }
     return {
       success: true,

--- a/server/src/controllers/verifiers/hasSID.mts
+++ b/server/src/controllers/verifiers/hasSID.mts
@@ -1,19 +1,18 @@
 import { isDocument } from "@typegoose/typegoose";
 import mainLogger from "../../logger.mjs";
-import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "hasSID";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function hasSID({
-  _id,
-  SID,
-  departureAirportInfo,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const hasSID: VerifierFunction = async function (
+  { _id, SID, departureAirportInfo },
+  saveResult = true
+): Promise<VerifierControllerResult> {
   // Set up the default result for a successful run of the verifier.
-  const result = new VerifierResultModel({
+  let result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
     flightPlanPart: "route",
@@ -43,10 +42,12 @@ export default async function hasSID({
       result.messageId = "hasSID";
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      result = await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -59,4 +60,6 @@ export default async function hasSID({
       error: `Error running hasSID: ${error.message}`,
     };
   }
-}
+};
+
+export default hasSID;

--- a/server/src/controllers/verifiers/hasValidFirstFix.mts
+++ b/server/src/controllers/verifiers/hasValidFirstFix.mts
@@ -3,16 +3,15 @@ import mainLogger from "../../logger.mjs";
 import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 
 const verifierName = "hasValidFirstFix";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function hasValidFirstFix({
-  _id,
-  routeParts,
-  SID,
-  SIDInformation,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const hasValidFirstFix: VerifierFunction = async function (
+  { _id, routeParts, SID, SIDInformation },
+  saveResult = true
+) {
   // Set up the default result for a successful run of the verifier.
   const result = new VerifierResultModel({
     flightPlanId: _id,
@@ -63,10 +62,13 @@ export default async function hasValidFirstFix({
       result.messageId = "firstFixIsValid";
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      await result.save();
+    }
+
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -79,4 +81,6 @@ export default async function hasValidFirstFix({
       error: `Error running hasValidFirstFix: ${error.message}`,
     };
   }
-}
+};
+
+export default hasValidFirstFix;

--- a/server/src/controllers/verifiers/jetIsNotSlantA.mts
+++ b/server/src/controllers/verifiers/jetIsNotSlantA.mts
@@ -3,16 +3,15 @@ import mainLogger from "../../logger.mjs";
 import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 
 const verifierName = "jetIsNotSlantA";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function jetIsNotSlantA({
-  _id,
-  equipmentCode,
-  equipmentSuffix,
-  equipmentInfo,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const jetIsNotSlantA: VerifierFunction = async function (
+  { _id, equipmentCode, equipmentSuffix, equipmentInfo },
+  saveResult = true
+) {
   // Set up the default result for a successful run of the verifier.
   const result = new VerifierResultModel({
     flightPlanId: _id,
@@ -45,10 +44,12 @@ export default async function jetIsNotSlantA({
       result.message = `${equipmentCode} with /A is almost certainly not correct.`;
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -61,4 +62,6 @@ export default async function jetIsNotSlantA({
       error: `Error running : ${error.message}`,
     };
   }
-}
+};
+
+export default jetIsNotSlantA;

--- a/server/src/controllers/verifiers/jetsOnlyOnRNAV.mts
+++ b/server/src/controllers/verifiers/jetsOnlyOnRNAV.mts
@@ -3,15 +3,15 @@ import mainLogger from "../../logger.mjs";
 import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 
 const verifierName = "jetsOnlyOnRNAV";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function jetsOnlyOnRNAV({
-  _id,
-  equipmentInfo,
-  SIDInformation,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const jetsOnlyOnRNAV: VerifierFunction = async function (
+  { _id, equipmentInfo, SIDInformation },
+  saveResult = true
+) {
   // Set up the default result for a successful run of the verifier.
   const result = new VerifierResultModel({
     flightPlanId: _id,
@@ -45,10 +45,12 @@ export default async function jetsOnlyOnRNAV({
       result.messageId = "engineTypeMatchesSID";
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -61,4 +63,6 @@ export default async function jetsOnlyOnRNAV({
       error: `Error running jetsOnlyOnRNAV: ${error.message}`,
     };
   }
-}
+};
+
+export default jetsOnlyOnRNAV;

--- a/server/src/controllers/verifiers/nonRNAVHasAirways.mts
+++ b/server/src/controllers/verifiers/nonRNAVHasAirways.mts
@@ -1,17 +1,16 @@
 import mainLogger from "../../logger.mjs";
 import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "nonRNAVHasAirways";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function nonRNAVHasAirways({
-  _id,
-  isRNAVCapable,
-  routeHasNonRNAVAirways,
-  equipmentSuffix,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const nonRNAVHasAirways: VerifierFunction = async function (
+  { _id, isRNAVCapable, routeHasNonRNAVAirways, equipmentSuffix },
+  saveResult = true
+) {
   // Set up the default result for a successful run of the verifier.
   const result = new VerifierResultModel({
     flightPlanId: _id,
@@ -46,10 +45,12 @@ export default async function nonRNAVHasAirways({
       result.priority = 1;
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -62,4 +63,6 @@ export default async function nonRNAVHasAirways({
       error: `Error running verifyNonRNAVHasAirways: ${error.message}`,
     };
   }
-}
+};
+
+export default nonRNAVHasAirways;

--- a/server/src/controllers/verifiers/nonRVSMIsBelow290.mts
+++ b/server/src/controllers/verifiers/nonRVSMIsBelow290.mts
@@ -1,17 +1,16 @@
 import mainLogger from "../../logger.mjs";
 import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "nonRVSMIsBelow290";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function nonRVSMIsBelow290({
-  _id,
-  isRVSMCapable,
-  cruiseAltitude,
-  equipmentSuffix,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const nonRVSMIsBelow290: VerifierFunction = async function (
+  { _id, isRVSMCapable, cruiseAltitude, equipmentSuffix },
+  saveResult = true
+) {
   // Set up the default result for a successful run of the verifier.
   const result = new VerifierResultModel({
     flightPlanId: _id,
@@ -47,10 +46,12 @@ export default async function nonRVSMIsBelow290({
       result.messageId = "nonRVSMBelow290";
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -63,4 +64,6 @@ export default async function nonRVSMIsBelow290({
       error: `Error running verifyNonRVSMIsBelow290: ${error.message}`,
     };
   }
-}
+};
+
+export default nonRVSMIsBelow290;

--- a/server/src/controllers/verifiers/pistonNotSlantLorZ.mts
+++ b/server/src/controllers/verifiers/pistonNotSlantLorZ.mts
@@ -3,15 +3,15 @@ import mainLogger from "../../logger.mjs";
 import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 
 const verifierName = "pistonNotSlantLorZ";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function pistonNotSlantLorZ({
-  _id,
-  equipmentSuffix,
-  equipmentInfo,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const pistonNotSlantLorZ: VerifierFunction = async function (
+  { _id, equipmentSuffix, equipmentInfo },
+  saveResult = true
+) {
   // Set up the default result for a successful run of the verifier.
   const result = new VerifierResultModel({
     flightPlanId: _id,
@@ -48,10 +48,12 @@ export default async function pistonNotSlantLorZ({
       result.priority = 5;
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -64,4 +66,6 @@ export default async function pistonNotSlantLorZ({
       error: `Error running pistonNotSlantLorZ: ${error.message}`,
     };
   }
-}
+};
+
+export default pistonNotSlantLorZ;

--- a/server/src/controllers/verifiers/routeWithFlightAware.mts
+++ b/server/src/controllers/verifiers/routeWithFlightAware.mts
@@ -4,18 +4,15 @@ import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 import { getFlightAwareRoutes } from "../flightAwareRoutes.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 
 const verifierName = "routeWithFlightAware";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function routeWithFlightAware({
-  _id,
-  departure,
-  arrival,
-  cleanedRoute,
-  SID,
-  cruiseAltitude,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const routeWithFlightAware: VerifierFunction = async function (
+  { _id, departure, arrival, cleanedRoute, SID, cruiseAltitude },
+  saveResult = true
+) {
   const result = new VerifierResultModel({
     flightPlanId: _id,
     verifier: verifierName,
@@ -93,10 +90,12 @@ export default async function routeWithFlightAware({
       result.priority = 4;
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -109,4 +108,6 @@ export default async function routeWithFlightAware({
       error: `Error running verifyRouteWithFlightAware: ${error.message}`,
     };
   }
-}
+};
+
+export default routeWithFlightAware;

--- a/server/src/controllers/verifiers/validArrivalAirport.mts
+++ b/server/src/controllers/verifiers/validArrivalAirport.mts
@@ -1,16 +1,16 @@
 import mainLogger from "../../logger.mjs";
 import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "validArrivalAirport";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function validArrivalAirport({
-  _id,
-  arrivalAirportInfo,
-  arrival,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const validArrivalAirport: VerifierFunction = async function (
+  { _id, arrivalAirportInfo, arrival },
+  saveResult = true
+) {
   // Set up the default result for a successful run of the verifier.
   const result = new VerifierResultModel({
     flightPlanId: _id,
@@ -32,10 +32,12 @@ export default async function validArrivalAirport({
       result.messageId = "validArrivalAirport";
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -48,4 +50,6 @@ export default async function validArrivalAirport({
       error: `Error running validArrivalAirport: ${error.message}`,
     };
   }
-}
+};
+
+export default validArrivalAirport;

--- a/server/src/controllers/verifiers/validDepartureAirport.mts
+++ b/server/src/controllers/verifiers/validDepartureAirport.mts
@@ -1,16 +1,16 @@
 import mainLogger from "../../logger.mjs";
 import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "validDepartureAirport";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function validDepartureAirport({
-  _id,
-  departure,
-  departureAirportInfo,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const validDepartureAirport: VerifierFunction = async function (
+  { _id, departure, departureAirportInfo },
+  saveResult = true
+) {
   // Set up the default result for a successful run of the verifier.
   const result = new VerifierResultModel({
     flightPlanId: _id,
@@ -32,10 +32,12 @@ export default async function validDepartureAirport({
       result.messageId = "validDepartureAirport";
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -48,4 +50,6 @@ export default async function validDepartureAirport({
       error: `Error running validDepartureAirport: ${error.message}`,
     };
   }
-}
+};
+
+export default validDepartureAirport;

--- a/server/src/controllers/verifiers/warnHeavyRunwayAssignment.mts
+++ b/server/src/controllers/verifiers/warnHeavyRunwayAssignment.mts
@@ -4,16 +4,15 @@ import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 import { joinWithWord } from "../../utils/formatting.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 
 const verifierName = "warnHeavyRunwayAssignment";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function warnHeavyRunwayAssignment({
-  _id,
-  isHeavy,
-  isSuper,
-  departureAirportInfo,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const warnHeavyRunwayAssignment: VerifierFunction = async function (
+  { _id, isHeavy, isSuper, departureAirportInfo },
+  saveResult = true
+) {
   // Set up the default result for a successful run of the verifier.
   const result = new VerifierResultModel({
     flightPlanId: _id,
@@ -58,10 +57,12 @@ export default async function warnHeavyRunwayAssignment({
       result.priority = 3;
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -74,4 +75,6 @@ export default async function warnHeavyRunwayAssignment({
       error: `Error running ${verifierName}: ${error.message}`,
     };
   }
-}
+};
+
+export default warnHeavyRunwayAssignment;

--- a/server/src/controllers/verifiers/warnNewPilot.mts
+++ b/server/src/controllers/verifiers/warnNewPilot.mts
@@ -4,14 +4,12 @@ import mainLogger from "../../logger.mjs";
 import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 
 const verifierName = "warnNewPilot";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function warnNewPilot({
-  _id,
-  pilotStats,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const warnNewPilot: VerifierFunction = async function ({ _id, pilotStats }, saveResult = true) {
   // Set up the default result for a successful run of the verifier.
   const result = new VerifierResultModel({
     flightPlanId: _id,
@@ -47,10 +45,12 @@ export default async function warnNewPilot({
       result.messageId = "pilotNotNew";
     }
 
-    const doc = await result.save();
+    if (saveResult) {
+      await result.save();
+    }
     return {
       success: true,
-      data: doc,
+      data: result,
     };
   } catch (err) {
     const error = err as Error;
@@ -63,4 +63,6 @@ export default async function warnNewPilot({
       error: `Error running warnNewPilot: ${error.message}`,
     };
   }
-}
+};
+
+export default warnNewPilot;

--- a/server/src/controllers/verifiers/warnTextOnlyPilot.mts
+++ b/server/src/controllers/verifiers/warnTextOnlyPilot.mts
@@ -2,55 +2,59 @@ import mainLogger from "../../logger.mjs";
 import { FlightPlan } from "../../models/FlightPlan.mjs";
 import { VatsimCommunicationMethod } from "../../models/VatsimFlightPlan.mjs";
 import { VerifierResultModel, VerifierResultStatus } from "../../models/VerifierResult.mjs";
+import { VerifierFunction } from "../../types/verifier.mjs";
 import VerifierControllerResult from "../../types/verifierControllerResult.mjs";
 
 const verifierName = "warnTextOnlyPilot";
 const logger = mainLogger.child({ service: verifierName });
 
-export default async function warnTextOnlyPilot({
-  _id,
-  communicationMethod,
-}: FlightPlan): Promise<VerifierControllerResult> {
+const warnTextOnlyPilot: VerifierFunction = async function warnTextOnlyPilot(
+  { _id, communicationMethod },
+  saveResult = true
+) {
   // Set up the default result for a successful run of the verifier.
-  let result: VerifierControllerResult = {
-    success: true,
-    data: new VerifierResultModel({
-      flightPlanId: _id,
-      verifier: verifierName,
-      flightPlanPart: "callsign",
-      priority: 5,
-    }),
-  };
+  const result = new VerifierResultModel({
+    flightPlanId: _id,
+    verifier: verifierName,
+    flightPlanPart: "callsign",
+    priority: 5,
+  });
 
   try {
     // This is the test the verifier is supposed to do.
     if (communicationMethod === VatsimCommunicationMethod.TEXTONLY) {
-      result.data.status = VerifierResultStatus.WARNING;
-      result.data.message = `Pilot is a text-only pilot`;
-      result.data.messageId = "textOnlyPilot";
-      result.data.priority = 5;
+      result.status = VerifierResultStatus.WARNING;
+      result.message = `Pilot is a text-only pilot`;
+      result.messageId = "textOnlyPilot";
+      result.priority = 5;
     } else if (communicationMethod === VatsimCommunicationMethod.RECEIVE) {
-      result.data.status = VerifierResultStatus.INFORMATION;
-      result.data.message = `Pilot is a receive pilot`;
-      result.data.messageId = "receivePilot";
+      result.status = VerifierResultStatus.INFORMATION;
+      result.message = `Pilot is a receive pilot`;
+      result.messageId = "receivePilot";
     } else {
-      result.data.status = VerifierResultStatus.INFORMATION;
-      result.data.message = `Pilot is a voice pilot`;
-      result.data.messageId = "voicePilot";
+      result.status = VerifierResultStatus.INFORMATION;
+      result.message = `Pilot is a voice pilot`;
+      result.messageId = "voicePilot";
     }
 
-    await result.data.save();
+    if (saveResult) {
+      result.save();
+    }
+    return {
+      success: true,
+      data: result,
+    };
   } catch (err) {
     const error = err as Error;
 
     logger.error(`Error running warnTextOnlyPilot: ${error.message}`, error);
 
-    result = {
+    return {
       success: false,
       errorType: "UnknownError",
       error: `Error running warnTextOnlyPilot: ${error.message}`,
     };
   }
+};
 
-  return result;
-}
+export default warnTextOnlyPilot;

--- a/server/src/controllers/verifyAll.mts
+++ b/server/src/controllers/verifyAll.mts
@@ -1,0 +1,39 @@
+import mainLogger from "../logger.mjs";
+import { FlightPlan } from "../models/FlightPlan.mjs";
+import { VerifierResultDocument, VerifierResultModel } from "../models/VerifierResult.mjs";
+import { logMongoBulkErrors } from "../utils.mjs";
+import { verifiers } from "./verifiers/allVerifiers.mjs";
+import VerifyAllResult from "./verifyAllResult.mjs";
+
+const logger = mainLogger.child({ service: "verifyAll" });
+
+export async function verifyAll(flightPlan: FlightPlan): Promise<VerifyAllResult> {
+  const verifyAllResult = new VerifyAllResult();
+  const verifierResultDocuments: VerifierResultDocument[] = [];
+
+  // Loop across all registered verifiers and save all successful verification runs
+  // to send back to the client.
+  await Promise.all(
+    verifiers.map(async (verifier) => {
+      return verifier.handler(flightPlan, false).then((result) => {
+        if (result.success) {
+          // Handles the case of verifiers returning multiple results, e.g. the checkForCustom*Messages verifiers
+          if (result.data instanceof Array) {
+            verifyAllResult.addMany(result.data);
+            verifierResultDocuments.concat(result.data);
+          } else {
+            verifyAllResult.add(result.data);
+            verifierResultDocuments.push(result.data);
+          }
+        }
+      });
+    })
+  );
+
+  try {
+    await VerifierResultModel.bulkSave(verifierResultDocuments);
+  } catch (err) {
+    logMongoBulkErrors(logger, err);
+  }
+  return verifyAllResult;
+}

--- a/server/src/controllers/verifyAll.mts
+++ b/server/src/controllers/verifyAll.mts
@@ -35,5 +35,6 @@ export async function verifyAll(flightPlan: FlightPlan): Promise<VerifyAllResult
   } catch (err) {
     logMongoBulkErrors(logger, err);
   }
+
   return verifyAllResult;
 }

--- a/server/src/types/verifier.mts
+++ b/server/src/types/verifier.mts
@@ -1,0 +1,14 @@
+import { FlightPlan } from "../models/FlightPlan.mjs";
+import VerifierControllerResult, {
+  VerifierControllerMultiResult,
+} from "./verifierControllerResult.mjs";
+
+export type VerifierFunction = (
+  flightPlan: FlightPlan,
+  saveResult: boolean
+) => Promise<VerifierControllerResult | VerifierControllerMultiResult>;
+
+export type Verifier = {
+  name: string;
+  handler: VerifierFunction;
+};

--- a/server/src/types/verifier.mts
+++ b/server/src/types/verifier.mts
@@ -5,6 +5,9 @@ import VerifierControllerResult, {
 
 export type VerifierFunction = (
   flightPlan: FlightPlan,
+  // Save result defaults to true in all the verifier functions. It gets set
+  // to false when functions are called by verifyAll() to allow for bulk
+  // saving the results afterwards as a performance improvement.
   saveResult?: boolean
 ) => Promise<VerifierControllerResult | VerifierControllerMultiResult>;
 

--- a/server/src/types/verifier.mts
+++ b/server/src/types/verifier.mts
@@ -5,7 +5,7 @@ import VerifierControllerResult, {
 
 export type VerifierFunction = (
   flightPlan: FlightPlan,
-  saveResult: boolean
+  saveResult?: boolean
 ) => Promise<VerifierControllerResult | VerifierControllerMultiResult>;
 
 export type Verifier = {


### PR DESCRIPTION
Fixes #1044

* Bundle the results and save them all at the end
* Properly return the awaits then do a Promise.all on all the verifiers at once.