### PR TITLE
Make CORS whitelist setting more robust

### DIFF
--- a/server/src/server.mts
+++ b/server/src/server.mts
@@ -23,7 +23,6 @@ import pkg from "lodash";
 const { debounce } = pkg;
 
 // Authentication
-import { verifyApiKey } from "./middleware/apikey.mjs";
 
 // Routes
 import activeFlightPlansRouter from "./routes/activeFlightPlans.mjs";
@@ -53,7 +52,7 @@ import vatsimTransceiversRouter from "./routes/vatsim/transceivers.mjs";
 // Admin routes
 import adminRouter from "./routes/admin.mjs";
 
-import { isOriginAllowed } from "./utils/cors.mjs";
+import { isOriginAllowed, setWhitelist } from "./utils/cors.mjs";
 
 export const app = express();
 let server: https.Server | Server;
@@ -95,6 +94,8 @@ function readCertsSync() {
 }
 
 export async function startServer(port: number): Promise<void> {
+  setWhitelist(ENV.WHITELISTED_DOMAINS);
+
   app.set("trust proxy", ENV.TRUST_PROXY);
   app.use(compression());
   app.use(bodyParser.urlencoded({ extended: false }));

--- a/server/src/utils/cors.mts
+++ b/server/src/utils/cors.mts
@@ -1,18 +1,22 @@
-import { ENV } from "../env.mjs";
 import mainLogger from "../logger.mjs";
 
 const logger = mainLogger.child({ service: "cors" });
 
-// Issue #953: Support splitting on comma and | to work around a Portainer
-// bug where override environment variables can't include a comma.
-// See https://github.com/portainer/portainer/issues/11091
-let whitelist = ENV.WHITELISTED_DOMAINS ? ENV.WHITELISTED_DOMAINS.split(/,|\|/) : [];
+let whitelist: string[] = [];
 
-logger.debug(`Whitelisted domains: ${whitelist.join(",")}`, { domains: whitelist });
-
-// Method to set the whitelist, for use with unit tests
-export function setWhitelist(whitelistedDomains: string) {
-  whitelist = whitelistedDomains.split(/,|\|/);
+export function setWhitelist(whitelistedDomains?: string) {
+  // Issue #953: Support splitting on comma and | to work around a Portainer
+  // bug where override environment variables can't include a comma.
+  // See https://github.com/portainer/portainer/issues/11091
+  // Issue #1027: Sometimes I accidentally include a trailing / on the URLs when specifying
+  // the whitelisted domains, which makes that test fail every time since the incoming URLs
+  // never have a trailing slash. Add the map to strip the trailing slash if it was provided.
+  if (!whitelistedDomains) {
+    whitelist = [];
+  } else {
+    whitelist = whitelistedDomains.split(/,|\|/).map((domain) => domain.replace(/\/$/, ""));
+  }
+  logger.debug(`Whitelisted domains: ${whitelist.join(",")}`, { domains: whitelist });
 }
 
 // Function to check if the origin matches any of the whitelisted domains.

--- a/server/src/utils/cors.mts
+++ b/server/src/utils/cors.mts
@@ -6,9 +6,14 @@ const logger = mainLogger.child({ service: "cors" });
 // Issue #953: Support splitting on comma and | to work around a Portainer
 // bug where override environment variables can't include a comma.
 // See https://github.com/portainer/portainer/issues/11091
-const whitelist = ENV.WHITELISTED_DOMAINS ? ENV.WHITELISTED_DOMAINS.split(/,|\|/) : [];
+let whitelist = ENV.WHITELISTED_DOMAINS ? ENV.WHITELISTED_DOMAINS.split(/,|\|/) : [];
 
 logger.debug(`Whitelisted domains: ${whitelist.join(",")}`, { domains: whitelist });
+
+// Method to set the whitelist, for use with unit tests
+export function setWhitelist(whitelistedDomains: string) {
+  whitelist = whitelistedDomains.split(/,|\|/);
+}
 
 // Function to check if the origin matches any of the whitelisted domains.
 export function isOriginAllowed(origin: string): boolean {

--- a/server/test/cors.spec.mts
+++ b/server/test/cors.spec.mts
@@ -6,12 +6,19 @@ describe("CORS wildcard validation", function () {
   it("should pass", async function () {
     let result = false;
 
+    // Simple case
     setWhitelist("https://www.badcasserole.com");
     result = isOriginAllowed("https://www.badcasserole.com");
     expect(result).to.be.equal(true);
 
+    // Wildcards in a list
     setWhitelist("https://www.badcasserole.com|https://*.vatsim-plan-verifier.pages.dev");
     result = isOriginAllowed("https://8e69efe7.vatsim-plan-verifier.pages.dev");
+    expect(result).to.be.equal(true);
+
+    // Issue #1027: Incorrect trailing slash
+    setWhitelist("https://www.badcasserole.com/");
+    result = isOriginAllowed("https://www.badcasserole.com");
     expect(result).to.be.equal(true);
   });
 });

--- a/server/test/cors.spec.mts
+++ b/server/test/cors.spec.mts
@@ -1,0 +1,17 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { isOriginAllowed, setWhitelist } from "../src/utils/cors.mjs";
+
+describe("CORS wildcard validation", function () {
+  it("should pass", async function () {
+    let result = false;
+
+    setWhitelist("https://www.badcasserole.com");
+    result = isOriginAllowed("https://www.badcasserole.com");
+    expect(result).to.be.equal(true);
+
+    setWhitelist("https://www.badcasserole.com|https://*.vatsim-plan-verifier.pages.dev");
+    result = isOriginAllowed("https://8e69efe7.vatsim-plan-verifier.pages.dev");
+    expect(result).to.be.equal(true);
+  });
+});


### PR DESCRIPTION
Fixes #1027 

* Add a function to set the whitelist
* Strip any trailing `/` on whitelist URLs
* Add unit tests to verify things work