### PR TITLE
Use the revision_id from VATSIM to reduce database $sets

### DIFF
--- a/server/src/models/VatsimFlightPlan.mts
+++ b/server/src/models/VatsimFlightPlan.mts
@@ -104,6 +104,10 @@ class VatsimFlightPlan {
   @prop({ required: false, default: false })
   sentEDCT: boolean = false;
 
+  // This is the revision for the flight plan data that VATSIM provides.
+  @prop({ required: false })
+  flightPlanRevision?: number;
+
   public setRevision(this: VatsimFlightPlanDocument) {
     // Find all the modified paths that trigger a revision bump.
     const modifiedPaths = this.modifiedPaths().filter((path) => !excludedPaths.includes(path));
@@ -118,20 +122,25 @@ class VatsimFlightPlan {
   }
 
   public async updateFlightPlan(this: VatsimFlightPlanDocument, incomingPlan: IVatsimPilot) {
-    this.flightRules = incomingPlan.flight_plan?.flight_rules ?? "";
-    this.name = incomingPlan.flight_plan?.name ?? "";
-    this.rawAircraftType = incomingPlan.flight_plan?.aircraft_faa ?? "";
-    this.departure = incomingPlan.flight_plan?.departure ?? "";
-    this.arrival = incomingPlan.flight_plan?.arrival ?? "";
-    this.squawk = incomingPlan.flight_plan?.assigned_transponder ?? "";
-    this.remarks = incomingPlan.flight_plan?.remarks ?? "";
+    // Only try updating the flight plan properties if the revision changed on the VATSIM side.
+    if (this.flightPlanRevision !== incomingPlan.flight_plan?.revision_id) {
+      this.arrival = incomingPlan.flight_plan?.arrival ?? "";
+      this.departure = incomingPlan.flight_plan?.departure ?? "";
+      this.departureTime = depTimeToDateTime(incomingPlan?.flight_plan?.deptime);
+      this.flightPlanRevision = incomingPlan.flight_plan?.revision_id;
+      this.flightRules = incomingPlan.flight_plan?.flight_rules ?? "";
+      this.name = incomingPlan.flight_plan?.name ?? "";
+      this.rawAircraftType = incomingPlan.flight_plan?.aircraft_faa ?? "";
+      this.remarks = incomingPlan.flight_plan?.remarks ?? "";
+      this.route = cleanRoute(incomingPlan.flight_plan?.route ?? "");
+      this.route = incomingPlan.flight_plan?.route;
+      this.squawk = incomingPlan.flight_plan?.assigned_transponder ?? "";
+    }
+
     this.isPrefile = incomingPlan.isPrefile;
-    this.route = incomingPlan.flight_plan?.route;
     this.coastAt = undefined; // Handles planes that reconnect after briefly disconnecting
 
     // Set the special properties that need calculations
-    this.route = cleanRoute(incomingPlan.flight_plan?.route ?? "");
-    this.departureTime = depTimeToDateTime(incomingPlan?.flight_plan?.deptime);
     this.communicationMethod = getCommunicationMethod(this.remarks);
     this.setCruiseAltitudeAndFlightRules(
       incomingPlan.flight_plan?.altitude,

--- a/server/src/services/vatsim.mts
+++ b/server/src/services/vatsim.mts
@@ -49,6 +49,7 @@ export async function getVatsimData(endpoint: string) {
   // then load and use that instead of retrieving from the real server.
   // This enables making specific changes to flights and testing the results.
   if (ENV.VATSIM_DATA_FILE) {
+    logger.debug(`Using VATSIM data from ${ENV.VATSIM_DATA_FILE}`);
     const data = await fs.promises.readFile(ENV.VATSIM_DATA_FILE, "utf-8");
     const vatsimData: IVatsimData = JSON.parse(data);
 

--- a/vatsim-data.json
+++ b/vatsim-data.json
@@ -27455,8 +27455,8 @@
         "enroute_time": "0029",
         "fuel_time": "0150",
         "remarks": "PBN/A1B2C2D2O2 DOF/240220 REG/N639FE EET/EDWW0004 LKAA0020 EDUU0031 LOVV0042 EDMM0044 OPR/FDX PER/C RMK/TCAS SIMBRIEF /V/",
-        "route": "SEA8 SEA BUWZO KRATR2",
-        "revision_id": 1,
+        "route": "MONTN2 SEA BUWZO KRATR2",
+        "revision_id": 2,
         "assigned_transponder": "5102"
       },
       "last_updated": "2024-02-20T21:51:57.031114Z"


### PR DESCRIPTION
Fixes #1093 

On the order of 10s of milliseconds of time savings with 900 records. Not much, but I'll take it.