### PR TITLE
Preferred routes complains when the route matches

### DIFF
--- a/server/src/controllers/verifiers/checkForPreferredRoutes.mts
+++ b/server/src/controllers/verifiers/checkForPreferredRoutes.mts
@@ -69,7 +69,7 @@ const checkForPreferredRoutes: VerifierFunction = async function (flightPlan, sa
       return (
         isDocument(flightPlan.equipmentInfo) &&
         route.route === flightPlan.route &&
-        (route.flow === AirportFlow.Any || route.flow === flightPlan.flow) &&
+        ((route.flow ?? AirportFlow.Any) === AirportFlow.Any || route.flow === flightPlan.flow) &&
         flightPlan.cruiseAltitude >= route.minimumRequiredAltitude &&
         (flightPlan.equipmentInfo?.maxCruiseSpeed ?? 999) >= route.minimumRequiredSpeed
       );


### PR DESCRIPTION
Fixes #1104

Caused by the preferred route's flow being undefined. If it's undefined assume it is `Any`. Problem solved.