### PR TITLE
Sleepytime SIDs should check for flow

### DIFF
--- a/server/scripts/add_departures.js
+++ b/server/scripts/add_departures.js
@@ -1137,9 +1137,9 @@ db.departures.insertMany([
         ExpectRequired: false,
         ExpectInMinutes: 5,
         InitialPhrasing: "ClimbViaSid",
-        Flow: "NORTH",
       },
     ],
+    Flow: "NORTH",
     IsRNAV: true,
     Charts: {
       skyvector: "https://skyvector.com/files/tpp/2307/pdf/00582ISBRG.PDF",
@@ -1162,9 +1162,9 @@ db.departures.insertMany([
         ExpectRequired: false,
         ExpectInMinutes: 5,
         InitialPhrasing: "ClimbViaSid",
-        Flow: "NORTH",
       },
     ],
+    Flow: "NORTH",
     IsRNAV: true,
     Charts: {
       skyvector: "https://skyvector.com/files/tpp/2307/pdf/00582OZWLD.PDF",
@@ -1187,9 +1187,9 @@ db.departures.insertMany([
         ExpectRequired: false,
         ExpectInMinutes: 5,
         InitialPhrasing: "ClimbViaSid",
-        Flow: "NORTH",
       },
     ],
+    Flow: "NORTH",
     IsRNAV: true,
     Charts: {
       skyvector: "https://skyvector.com/files/tpp/2307/pdf/00582JEFPO.PDF",

--- a/server/src/models/Departure.mts
+++ b/server/src/models/Departure.mts
@@ -10,7 +10,7 @@ import { find } from "geo-tz";
 import { DateTime } from "luxon";
 import { SpeedGooseCacheAutoCleaner } from "speedgoose";
 import { AirportInfoModel } from "./AirportInfo.mjs";
-import { InitialAltitude } from "./InitialAltitude.mjs";
+import { AirportFlow, InitialAltitude } from "./InitialAltitude.mjs";
 
 export class DepartureValidity {
   @prop({ required: true })
@@ -61,6 +61,9 @@ export class Departure {
 
   @prop({ type: String })
   Charts?: Map<string, string>;
+
+  @prop({ required: true, enum: AirportFlow, default: AirportFlow.Any })
+  Flow!: AirportFlow;
 
   // Returns true if the departure is valid given its start and end times and the current
   // local time at the departure's airport.


### PR DESCRIPTION
Fixes #1102

This introduces `Flow` on the `Departure` model. For now that's just used for checking sleepytime SIDs, but can be used elsewhere eventually, e.g. to have two different `SUMMA2` departures.