### PR TITLE
Plans are still showing updated way too often

### DIFF
--- a/client/src/hooks/useVatsim.mts
+++ b/client/src/hooks/useVatsim.mts
@@ -45,7 +45,7 @@ export function useVatsim() {
           }
           // It's an existing one so update it
           else {
-            const updated = incoming.revision !== existing.revision;
+            const updated = incoming.flightPlanRevision !== existing.flightPlanRevision;
 
             // This uses an if statement instead of the previous shorthand hasUpdates || updates
             // to avoid hasUpdates being a dependency of the callback, which was preventing
@@ -63,7 +63,7 @@ export function useVatsim() {
             existing.importState = updated ? ImportState.UPDATED : existing.importState;
             existing.isCoasting = incoming.isCoasting;
             existing.isPrefile = incoming.isPrefile;
-            existing.revision = incoming.revision;
+            existing.flightPlanRevision = incoming.flightPlanRevision;
           }
         });
       });

--- a/client/src/interfaces/IVatsimFlightPlan.mts
+++ b/client/src/interfaces/IVatsimFlightPlan.mts
@@ -12,6 +12,6 @@ export interface IVatsimFlightPlan {
   arrival?: string;
   departureTime?: string;
   importState?: ImportState;
-  revision: number;
+  flightPlanRevision: number;
   isCoasting: boolean;
 }


### PR DESCRIPTION
Fixes #1132

Move to an "include these properties in ones that cause updates" model instead of an "exclude these properties" model. Works so much better.