### PR TITLE
Add setting for sorting VATSIM plans by created date

### DIFF
--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -5,6 +5,7 @@ import { useRecoilState, useRecoilValue } from "recoil";
 import {
   autoHideImportedState,
   hideInformationalState,
+  sortByCreatedAtState,
   streamingModeState,
   userInfoState,
 } from "../context/atoms";
@@ -17,6 +18,7 @@ interface SettingsDialogProps {
 
 export const SettingsDialog = (props: SettingsDialogProps) => {
   const { onClose, open } = props;
+  const [sortByCreatedAt, setSortByCreatedAt] = useRecoilState(sortByCreatedAtState);
   const [autoHideImported, setAutoHideImported] = useRecoilState(autoHideImportedState);
   const [hideInformational, setHideInformational] = useRecoilState(hideInformationalState);
   const [streamingMode, setStreamingMode] = useRecoilState(streamingModeState);
@@ -26,6 +28,18 @@ export const SettingsDialog = (props: SettingsDialogProps) => {
     onClose();
   };
   const userInfo = useRecoilValue(userInfoState);
+
+  const handleSortByCreatedAtChanged = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      setSortByCreatedAt(event.target.checked);
+
+      const token = await getAccessTokenSilently();
+      await putUserInfo(token, {
+        sortByCreatedAt: event.target.checked,
+      });
+    },
+    [getAccessTokenSilently, setSortByCreatedAt]
+  );
 
   const handleAutoHideChanged = useCallback(
     async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -67,6 +81,19 @@ export const SettingsDialog = (props: SettingsDialogProps) => {
     <Dialog open={open} onClose={handleClose}>
       <DialogTitle>Settings</DialogTitle>
       <Stack sx={{ ml: 2, mr: 2, mb: 2 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={sortByCreatedAt}
+              onChange={(event) => {
+                handleSortByCreatedAtChanged(event).catch((err) => {
+                  console.error(err);
+                });
+              }}
+            />
+          }
+          label="Sort VATSIM plans by created time"
+        />
         <FormControlLabel
           control={
             <Switch

--- a/client/src/components/VatsimFlightPlans.tsx
+++ b/client/src/components/VatsimFlightPlans.tsx
@@ -27,6 +27,7 @@ const VatsimFlightPlans = () => {
   const disconnectedPlayer = useAudio("/disconnected.mp3");
   const {
     flightPlans,
+    setFlightPlans,
     processFlightPlans,
     markPlanImported,
     hasUpdates,
@@ -118,6 +119,19 @@ const VatsimFlightPlans = () => {
     },
     [processFlightPlans, sortByCreatedAt]
   );
+
+  // Handles when the user toggles the sort method in the settings dialog.
+  // Without this the VATSIM list wouldn't re-sort until the next time the
+  // data gets received from the server.
+  useEffect(() => {
+    if (sortByCreatedAt) {
+      setFlightPlans((draft) =>
+        draft.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+      );
+    } else {
+      setFlightPlans((draft) => draft.sort((a, b) => a.callsign.localeCompare(b.callsign)));
+    }
+  }, [setFlightPlans, sortByCreatedAt]);
 
   useEffect(() => {
     socket.on("connect", handleConnect);

--- a/client/src/components/VatsimFlightPlans.tsx
+++ b/client/src/components/VatsimFlightPlans.tsx
@@ -5,19 +5,19 @@ import {
 } from "@mui/icons-material";
 import { Box, IconButton, List, ListItem, ListItemText, Stack, TextField } from "@mui/material";
 import debug from "debug";
+import { enqueueSnackbar } from "notistack";
 import pluralize from "pluralize";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useIdleTimer } from "react-idle-timer";
 import { useNavigate } from "react-router-dom";
 import { useRecoilValue } from "recoil";
-import { autoHideImportedState } from "../context/atoms";
+import { autoHideImportedState, sortByCreatedAtState } from "../context/atoms";
 import { useAppContext } from "../hooks/useAppContext.mjs";
 import { useAudio } from "../hooks/useAudio";
 import { useVatsim } from "../hooks/useVatsim.mts";
 import { IVatsimFlightPlan, ImportState } from "../interfaces/IVatsimFlightPlan.mts";
 import { importFlightPlan } from "../services/flightPlan.mts";
 import { getColorByStatus } from "../utils/vatsim.mts";
-import { enqueueSnackbar } from "notistack";
 
 const logger = debug("plan-verifier:vatsimFlightPlans");
 
@@ -46,6 +46,7 @@ const VatsimFlightPlans = () => {
   const airportCodesRef = useRef<string>(localStorage.getItem("vatsimAirportCodes") ?? "");
   const [isImporting, setIsImporting] = useState(false);
   const autoHideImported = useRecoilValue(autoHideImportedState);
+  const sortByCreatedAt = useRecoilValue(sortByCreatedAtState);
   const { socket } = useAppContext();
   const { getAccessTokenSilently } = useAuth0();
 
@@ -113,9 +114,9 @@ const VatsimFlightPlans = () => {
   const handleVatsimFlightPlansUpdate = useCallback(
     (incomingPlans: IVatsimFlightPlan[]) => {
       logger("Received vatsim flight plan update");
-      processFlightPlans(incomingPlans);
+      processFlightPlans(incomingPlans, sortByCreatedAt);
     },
-    [processFlightPlans]
+    [processFlightPlans, sortByCreatedAt]
   );
 
   useEffect(() => {

--- a/client/src/context/atoms.ts
+++ b/client/src/context/atoms.ts
@@ -2,6 +2,11 @@ import { atom } from "recoil";
 import { IAuth0User } from "../interfaces/IAuth0User.mts";
 import { AirportFlow } from "../interfaces/ISIDInformation.mts";
 
+export const sortByCreatedAtState = atom({
+  key: "sortByCreatedAtState",
+  default: false,
+});
+
 export const autoHideImportedState = atom({
   key: "autoHideImportedState",
   default: false,

--- a/client/src/hooks/useVatsim.mts
+++ b/client/src/hooks/useVatsim.mts
@@ -8,7 +8,7 @@ export function useVatsim() {
   const [hasNew, setHasNew] = useImmer<boolean>(false);
 
   const processFlightPlans = useCallback(
-    (incomingPlans: IVatsimFlightPlan[]) => {
+    (incomingPlans: IVatsimFlightPlan[], sortByCreatedAt: boolean) => {
       // If there are no incoming plans then just set an empty array.
       if (incomingPlans.length === 0) {
         setFlightPlans(() => {
@@ -72,10 +72,13 @@ export function useVatsim() {
         });
       });
 
-      setFlightPlans((draft) =>
-        draft.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
-      );
-      //      setFlightPlans((draft) => draft.sort((a, b) => a.callsign.localeCompare(b.callsign)));
+      if (sortByCreatedAt) {
+        setFlightPlans((draft) =>
+          draft.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+        );
+      } else {
+        setFlightPlans((draft) => draft.sort((a, b) => a.callsign.localeCompare(b.callsign)));
+      }
     },
     [setFlightPlans, setHasNew, setHasUpdates]
   );

--- a/client/src/hooks/useVatsim.mts
+++ b/client/src/hooks/useVatsim.mts
@@ -102,6 +102,7 @@ export function useVatsim() {
   return useMemo(
     () => ({
       flightPlans,
+      setFlightPlans,
       processFlightPlans,
       markPlanImported,
       hasUpdates,
@@ -111,6 +112,7 @@ export function useVatsim() {
     }),
     [
       flightPlans,
+      setFlightPlans,
       processFlightPlans,
       markPlanImported,
       hasUpdates,

--- a/client/src/hooks/useVatsim.mts
+++ b/client/src/hooks/useVatsim.mts
@@ -39,6 +39,8 @@ export function useVatsim() {
           if (!existing) {
             draft.push({
               ...incoming,
+              createdAt: new Date(incoming.createdAt),
+              updatedAt: new Date(incoming.updatedAt),
               importState: ImportState.NEW,
             } as IVatsimFlightPlan);
             setHasNew(true);
@@ -64,11 +66,16 @@ export function useVatsim() {
             existing.isCoasting = incoming.isCoasting;
             existing.isPrefile = incoming.isPrefile;
             existing.flightPlanRevision = incoming.flightPlanRevision;
+            existing.createdAt = new Date(incoming.createdAt);
+            existing.updatedAt = new Date(incoming.updatedAt);
           }
         });
       });
 
-      setFlightPlans((draft) => draft.sort((a, b) => a.callsign.localeCompare(b.callsign)));
+      setFlightPlans((draft) =>
+        draft.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+      );
+      //      setFlightPlans((draft) => draft.sort((a, b) => a.callsign.localeCompare(b.callsign)));
     },
     [setFlightPlans, setHasNew, setHasUpdates]
   );

--- a/client/src/interfaces/IAuth0User.mts
+++ b/client/src/interfaces/IAuth0User.mts
@@ -4,6 +4,7 @@ type Mode = "light" | "dark" | "system";
 
 export interface IAuth0User {
   _id: string;
+  sortByCreatedAt: boolean;
   autoHideImported: boolean;
   colorMode: Mode;
   email?: string;

--- a/client/src/interfaces/IVatsimFlightPlan.mts
+++ b/client/src/interfaces/IVatsimFlightPlan.mts
@@ -14,4 +14,6 @@ export interface IVatsimFlightPlan {
   importState?: ImportState;
   flightPlanRevision: number;
   isCoasting: boolean;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/server/src/models/Auth0User.mts
+++ b/server/src/models/Auth0User.mts
@@ -1,9 +1,9 @@
 import {
-  type DocumentType,
-  type ReturnModelType,
   getModelForClass,
   plugin,
   prop,
+  type DocumentType,
+  type ReturnModelType,
 } from "@typegoose/typegoose";
 import { ManagementClient } from "auth0";
 import { SpeedGooseCacheAutoCleaner } from "speedgoose";
@@ -28,6 +28,9 @@ export class Auth0User {
 
   @prop({ required: false, default: "light" })
   colorMode!: string;
+
+  @prop({ required: false, default: false })
+  sortByCreatedAt!: boolean;
 
   @prop({ required: false, default: true })
   hideInformational!: boolean;

--- a/server/src/models/VatsimFlightPlan.mts
+++ b/server/src/models/VatsimFlightPlan.mts
@@ -1,4 +1,10 @@
-import { type DocumentType, getModelForClass, modelOptions, prop } from "@typegoose/typegoose";
+import {
+  defaultClasses,
+  getModelForClass,
+  modelOptions,
+  prop,
+  type DocumentType,
+} from "@typegoose/typegoose";
 import _ from "lodash";
 import { DateTime } from "luxon";
 import { ENV } from "../env.mjs";
@@ -38,11 +44,12 @@ const flightPlanRevisionPaths = [
 @modelOptions({
   options: { customName: "vatsimflightplan" },
   schemaOptions: {
+    timestamps: true,
     toJSON: { virtuals: true },
     toObject: { virtuals: true },
   },
 })
-class VatsimFlightPlan {
+class VatsimFlightPlan extends defaultClasses.TimeStamps {
   @prop({ required: true })
   cid!: number;
 


### PR DESCRIPTION
Fixes #1186 

Add a setting to sort the VATSIM flight plans by `createdAt` instead of `callsign`